### PR TITLE
Fix issue where hanging indentation is not consistent within lists

### DIFF
--- a/tests/fixtures/out.01-default/3rdparty/php-doc/language/types/array/034.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-doc/language/types/array/034.php
@@ -1,6 +1,6 @@
 <?php
 $fruits = array('fruits' => array('a' => 'orange',
-            'b' => 'banana',
+        'b' => 'banana',
         'c' => 'apple'),
     'numbers' => array(1,
         2,

--- a/tests/fixtures/out.03-tab/3rdparty/php-doc/language/types/array/034.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-doc/language/types/array/034.php
@@ -1,6 +1,6 @@
 <?php
 $fruits = array('fruits' => array('a' => 'orange',
-			'b' => 'banana',
+		'b' => 'banana',
 		'c' => 'apple'),
 	'numbers' => array(1,
 		2,

--- a/tests/unit/Rule/HangingIndentationTest.php
+++ b/tests/unit/Rule/HangingIndentationTest.php
@@ -226,6 +226,39 @@ $foo = $bar->baz()
     ->quuux();
 PHP,
             ],
+            [
+                <<<'PHP'
+<?php
+$a = array('b' => array('c' => 'd',
+        'e' => 'f',
+        'g' => 'h'),
+    'i' => array(1,
+        2,
+        3,
+        4,
+        5,
+        6),
+    'j' => array('k',
+        7 => 'l',
+        'm'));
+
+PHP,
+                <<<'PHP'
+<?php
+$a = array('b' => array('c' => 'd',
+'e' => 'f',
+'g' => 'h'),
+'i' => array(1,
+2,
+3,
+4,
+5,
+6),
+'j' => array('k',
+7 => 'l',
+'m'));
+PHP,
+            ],
         ];
     }
 }


### PR DESCRIPTION
For example:

```php
<?php
$a = array('b' => array('c' => 'd',
            'e' => 'f',
        'g' => 'h'),
    'i' => array(1,
        2,
        3,
        4,
        5,
        6),
    'j' => array('k',
        5 => 'l',
        'm'));
