### PR TITLE
Improve `Formatter` API, fix empty statement and related bugs, review import sorting

### DIFF
--- a/src/Catalog/FormatterFlag.php
+++ b/src/Catalog/FormatterFlag.php
@@ -14,10 +14,16 @@ use Lkrms\Concept\Enumeration;
 final class FormatterFlag extends Enumeration
 {
     /**
+     * Collect warnings about non-critical problems detected in formatted code
+     *
+     */
+    public const COLLECT_CODE_PROBLEMS = 1;
+
+    /**
      * Print warnings about non-critical problems detected in formatted code
      *
      */
-    public const REPORT_CODE_PROBLEMS = 1;
+    public const REPORT_CODE_PROBLEMS = 2;
 
     /**
      * Enable debug mode
@@ -26,11 +32,11 @@ final class FormatterFlag extends Enumeration
      * returns `true`.
      *
      */
-    public const DEBUG = 2;
+    public const DEBUG = 4;
 
     /**
      * In debug mode, render output after processing each pass of each rule
      *
      */
-    public const LOG_PROGRESS = 4;
+    public const LOG_PROGRESS = 8;
 }

--- a/src/Catalog/ImportSortOrder.php
+++ b/src/Catalog/ImportSortOrder.php
@@ -24,16 +24,18 @@ final class ImportSortOrder extends Enumeration
     /**
      * Order imports by name
      *
-     * Grouped imports appear after ungrouped imports.
+     * Grouped imports receive no special treatment.
      *
      * Example:
      *
      * ```php
      * <?php
      * use A;
-     * use A\B;
-     * use A\B\C;
-     * use A\B\{D, E};
+     * use B\C\E;
+     * use B\C\F\G;
+     * use B\C\F\{H, I};
+     * use B\C\F\J;
+     * use B\D;
      * ```
      */
     public const NAME = 1;
@@ -47,9 +49,11 @@ final class ImportSortOrder extends Enumeration
      *
      * ```php
      * <?php
-     * use A\B\{D, E};
-     * use A\B\C;
-     * use A\B;
+     * use B\C\F\{H, I};
+     * use B\C\F\G;
+     * use B\C\F\J;
+     * use B\C\E;
+     * use B\D;
      * use A;
      * ```
      */

--- a/src/Command/FormatPhp.php
+++ b/src/Command/FormatPhp.php
@@ -591,7 +591,7 @@ Use `--sort-imports-by=none` to group import statements by type without changing
 their order.
 
 Unless disabled by `-M/--no-sort-imports`, the default is to sort imports by
-*name*.
+*depth*.
 EOF)
                 ->optionType(CliOptionType::ONE_OF)
                 ->allowedValues(array_keys(self::IMPORT_SORT_ORDER_MAP))
@@ -1035,7 +1035,7 @@ EOF,
                 }
                 $f->ImportSortOrder = $this->SortImportsBy
                     ? self::IMPORT_SORT_ORDER_MAP[$this->SortImportsBy]
-                    : ImportSortOrder::NAME;
+                    : ImportSortOrder::DEPTH;
                 $this->SpacesBesideCode === null || $f->SpacesBesideCode = $this->SpacesBesideCode;
                 $this->SymmetricalBrackets === null || $f->SymmetricalBrackets = $this->SymmetricalBrackets;
                 $this->IncreaseIndentBetweenUnenclosedTags === null || $f->IncreaseIndentBetweenUnenclosedTags = $this->IncreaseIndentBetweenUnenclosedTags;

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -285,7 +285,7 @@ final class Formatter implements IReadable
     private bool $_Psr12Compliance = false;
 
     /**
-     * @var Rule[]
+     * @var array<string,Rule>
      */
     private array $Rules;
 
@@ -295,38 +295,48 @@ final class Formatter implements IReadable
     private array $TokenRuleTypes;
 
     /**
-     * @var Filter[]
+     * @var array<string,Filter>
      */
     private array $Filters;
 
     /**
-     * @var Filter[]
+     * @var array<string,Filter>
      */
     private array $FormatFilters;
 
     /**
-     * @var Filter[]
+     * @var array<string,Filter>
      */
     private array $ComparisonFilters;
 
     /**
+     * @var array<int,Filter>
+     */
+    private array $FormatFilterList;
+
+    /**
+     * @var array<int,Filter>
+     */
+    private array $ComparisonFilterList;
+
+    /**
      * [ [ Rule object, method name ], ... ]
      *
-     * @var array<array{TokenRule|ListRule,string}>
+     * @var array<string,array{TokenRule|ListRule,string}>
      */
     private array $MainLoop;
 
     /**
      * [ [ Rule object, method name ], ... ]
      *
-     * @var array<array{BlockRule,string}>
+     * @var array<string,array{BlockRule,string}>
      */
     private array $BlockLoop;
 
     /**
      * [ [ Rule object, method name ], ... ]
      *
-     * @var array<array{Rule,string}>
+     * @var array<string,array{Rule,string}>
      */
     private array $BeforeRender;
 
@@ -500,6 +510,8 @@ final class Formatter implements IReadable
         );
 
         $this->Filters = array_merge($this->FormatFilters, $comparisonFilters);
+        $this->FormatFilterList = array_values($this->FormatFilters);
+        $this->ComparisonFilterList = array_values($this->ComparisonFilters);
     }
 
     public function __clone()
@@ -534,6 +546,8 @@ final class Formatter implements IReadable
                 $this->ComparisonFilters[$_filter] = $filter;
             }
         }
+        $this->FormatFilterList = array_values($this->FormatFilters);
+        $this->ComparisonFilterList = array_values($this->ComparisonFilters);
     }
 
     /**
@@ -626,7 +640,7 @@ final class Formatter implements IReadable
                 $code,
                 TOKEN_PARSE,
                 $this->TokenTypeIndex,
-                ...$this->FormatFilters
+                ...$this->FormatFilterList
             );
 
             if (!$this->Tokens) {
@@ -894,7 +908,7 @@ final class Formatter implements IReadable
             $tokensOut = Token::onlyTokenize(
                 $out,
                 TOKEN_PARSE,
-                ...$this->ComparisonFilters
+                ...$this->ComparisonFilterList
             );
         } catch (ParseError $ex) {
             throw new FormatterException(
@@ -912,7 +926,7 @@ final class Formatter implements IReadable
         $tokensIn = Token::onlyTokenize(
             $code,
             TOKEN_PARSE,
-            ...$this->ComparisonFilters
+            ...$this->ComparisonFilterList
         );
 
         $before = $this->simplifyTokens($tokensIn);

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\PrettyPHP;
 
+use Lkrms\Concern\HasMutator;
 use Lkrms\Concern\TReadable;
 use Lkrms\Contract\IReadable;
 use Lkrms\Facade\Console;
@@ -78,6 +79,9 @@ use Throwable;
  */
 final class Formatter implements IReadable
 {
+    use HasMutator {
+        withPropertyValue as public with;
+    }
     use TReadable;
 
     /**
@@ -117,6 +121,13 @@ final class Formatter implements IReadable
      * @var array<class-string<Rule>,true>
      */
     public array $EnabledRules;
+
+    /**
+     * False if calls to reportCodeProblem() are ignored
+     *
+     * @readonly
+     */
+    public bool $CollectCodeProblems;
 
     public string $PreferredEol = PHP_EOL;
 
@@ -165,7 +176,7 @@ final class Formatter implements IReadable
     /**
      * @var ImportSortOrder::*
      */
-    public int $ImportSortOrder = ImportSortOrder::NAME;
+    public int $ImportSortOrder = ImportSortOrder::DEPTH;
 
     /**
      * @var array<class-string<Rule>>
@@ -177,7 +188,7 @@ final class Formatter implements IReadable
         OperatorSpaces::class,           // processToken  (80)
         ControlStructureSpacing::class,  // processToken  (83)
         PlaceComments::class,            // processToken  (90), beforeRender (997)
-        PlaceBraces::class,              // processToken  (94), beforeRender (94)
+        PlaceBraces::class,              // processToken  (94), beforeRender (400)
         SymmetricalBrackets::class,      // processToken  (96)
         OperatorLineBreaks::class,       // processToken  (98)
         ListSpacing::class,              // processList   (98)
@@ -363,6 +374,7 @@ final class Formatter implements IReadable
         $this->Debug = $flags & FormatterFlag::DEBUG || Env::debug();
         $this->LogProgress = $this->Debug && $flags & FormatterFlag::LOG_PROGRESS;
         $this->ReportCodeProblems = (bool) ($flags & FormatterFlag::REPORT_CODE_PROBLEMS);
+        $this->CollectCodeProblems = $this->ReportCodeProblems || $flags & FormatterFlag::COLLECT_CODE_PROBLEMS;
 
         // If using tabs for indentation, disable incompatible rules
         if (!$insertSpaces) {
@@ -412,7 +424,7 @@ final class Formatter implements IReadable
             }
             /** @var Rule $rule */
             $rule = new $_rule($this);
-            $this->Rules[] = $rule;
+            $this->Rules[$_rule] = $rule;
             if ($rule instanceof TokenRule) {
                 $types = $rule->getTokenTypes();
                 $first = null;
@@ -434,19 +446,21 @@ final class Formatter implements IReadable
                     );
                 }
                 $this->TokenRuleTypes[$_rule] = $types;
+                $key = "$_rule:" . TokenRule::PROCESS_TOKEN;
                 if ($rule instanceof MultiTokenRule) {
-                    $mainLoop[] = [$rule, MultiTokenRule::PROCESS_TOKENS, $i];
+                    $mainLoop[$key] = [$rule, MultiTokenRule::PROCESS_TOKENS, $i];
                 } else {
-                    $mainLoop[] = [$rule, TokenRule::PROCESS_TOKEN, $i];
+                    $mainLoop[$key] = [$rule, TokenRule::PROCESS_TOKEN, $i];
                 }
             }
             if ($rule instanceof ListRule) {
-                $mainLoop[] = [$rule, ListRule::PROCESS_LIST, $i];
+                $key = "$_rule:" . ListRule::PROCESS_LIST;
+                $mainLoop[$key] = [$rule, ListRule::PROCESS_LIST, $i];
             }
             if ($rule instanceof BlockRule) {
-                $blockLoop[] = [$rule, BlockRule::PROCESS_BLOCK, $i];
+                $blockLoop[$_rule] = [$rule, BlockRule::PROCESS_BLOCK, $i];
             }
-            $beforeRender[] = [$rule, Rule::BEFORE_RENDER, $i];
+            $beforeRender[$_rule] = [$rule, Rule::BEFORE_RENDER, $i];
             $i++;
         }
         $this->MainLoop = $this->sortRules($mainLoop);
@@ -461,23 +475,65 @@ final class Formatter implements IReadable
                 $skipFilters
             )
         );
-        $filters = array_combine(
+
+        $this->FormatFilters = array_combine(
             $filters,
-            $this->FormatFilters = array_map(
+            array_map(
                 fn(string $filter) => new $filter($this),
                 $filters
             )
         );
+
         // Column values are unnecessary when comparing tokens
+        $filters = $this->FormatFilters;
         unset($filters[CollectColumn::class]);
+
         $this->ComparisonFilters = array_merge(
-            array_values($filters),
-            $comparisonFilters = array_map(
-                fn(string $filter) => new $filter($this),
-                self::COMPARISON_FILTERS
+            $filters,
+            $comparisonFilters = array_combine(
+                self::COMPARISON_FILTERS,
+                array_map(
+                    fn(string $filter) => new $filter($this),
+                    self::COMPARISON_FILTERS
+                )
             )
         );
+
         $this->Filters = array_merge($this->FormatFilters, $comparisonFilters);
+    }
+
+    public function __clone()
+    {
+        foreach ($this->Rules as $_rule => &$rule) {
+            $rule = clone $rule;
+            $rule->setFormatter($this);
+            if ($rule instanceof TokenRule &&
+                    ($this->MainLoop[$key = "$_rule:" . TokenRule::PROCESS_TOKEN] ?? null)) {
+                $this->MainLoop[$key][0] = $rule;
+            }
+            if ($rule instanceof ListRule &&
+                    ($this->MainLoop[$key = "$_rule:" . ListRule::PROCESS_LIST] ?? null)) {
+                $this->MainLoop[$key][0] = $rule;
+            }
+            if ($rule instanceof BlockRule &&
+                    ($this->BlockLoop[$_rule] ?? null)) {
+                $this->BlockLoop[$_rule][0] = $rule;
+            }
+            if ($this->BeforeRender[$_rule] ?? null) {
+                $this->BeforeRender[$_rule][0] = $rule;
+            }
+        }
+
+        foreach ($this->Filters as $_filter => &$filter) {
+            $filter = clone $filter;
+            $filter->setFormatter($this);
+            if ($this->FormatFilters[$_filter] ?? null) {
+                $this->FormatFilters[$_filter] = $filter;
+            }
+            if ($this->ComparisonFilters[$_filter] ?? null) {
+                $this->ComparisonFilters[$_filter] = $filter;
+            }
+        }
     }
 
     /**
@@ -501,15 +557,7 @@ final class Formatter implements IReadable
         $clone->HeredocIndent = HeredocIndent::HANGING;
         $clone->NewlineBeforeFnDoubleArrows = true;
         $clone->OneTrueBraceStyle = false;
-        $clone->ImportSortOrder = ImportSortOrder::NONE;
         $clone->_Psr12Compliance = true;
-
-        foreach ([
-            ...$this->Rules,
-            ...$this->Filters,
-        ] as $extension) {
-            $extension->setFormatter($clone);
-        }
 
         return $clone;
     }
@@ -887,7 +935,8 @@ final class Formatter implements IReadable
                 if ($filename) {
                     $values[] = $filename;
                     $values[] = $problem->Start->OutputLine;
-                    Console::warn(sprintf($problem->Message . ': %s:%d', ...$problem->Values, ...$values));
+                    $values[] = $problem->Start->OutputColumn;
+                    Console::warn(sprintf($problem->Message . ': %s:%d:%d', ...$problem->Values, ...$values));
                     continue;
                 }
 
@@ -952,7 +1001,7 @@ final class Formatter implements IReadable
         }
 
         // Sort by priority, then index
-        usort(
+        uasort(
             $rules,
             fn(array $a, array $b) =>
                 ($a[3] <=> $b[3]) ?: $a[2] <=> $b[2]
@@ -1006,8 +1055,11 @@ final class Formatter implements IReadable
      * @param string $message e.g. `"Unnecessary parentheses"`
      * @param mixed ...$values
      */
-    public function reportProblem(Rule $rule, string $message, Token $start, ?Token $end = null, ...$values): void
+    public function reportCodeProblem(Rule $rule, string $message, Token $start, ?Token $end = null, ...$values): void
     {
+        if (!$this->CollectCodeProblems) {
+            return;
+        }
         $this->CodeProblems[] = new CodeProblem($rule, $message, $start, $end, ...$values);
     }
 

--- a/src/Rule/AlignData.php
+++ b/src/Rule/AlignData.php
@@ -8,8 +8,7 @@ use Lkrms\PrettyPHP\Rule\Contract\BlockRule;
 use Lkrms\PrettyPHP\Token\Token;
 
 /**
- * Align consecutive assignment operators and double arrows when they have the
- * same context
+ * Align consecutive operators and values
  *
  */
 final class AlignData implements BlockRule

--- a/src/Rule/ControlStructureSpacing.php
+++ b/src/Rule/ControlStructureSpacing.php
@@ -4,24 +4,30 @@ namespace Lkrms\PrettyPHP\Rule;
 
 use Lkrms\PrettyPHP\Catalog\TokenType;
 use Lkrms\PrettyPHP\Catalog\WhitespaceType;
-use Lkrms\PrettyPHP\Rule\Concern\TokenRuleTrait;
-use Lkrms\PrettyPHP\Rule\Contract\TokenRule;
-use Lkrms\PrettyPHP\Token\Token;
-use Lkrms\PrettyPHP\Formatter;
+use Lkrms\PrettyPHP\Rule\Concern\MultiTokenRuleTrait;
+use Lkrms\PrettyPHP\Rule\Contract\MultiTokenRule;
 
 /**
- * Add newlines after control structures where the body has no enclosing braces
+ * Apply whitespace to control structures where the body has no enclosing braces
  *
- * Control structures meeting this criteria are also reported to the user via
- * {@see Formatter::reportProblem()}.
+ * Control structures that meet this criteria are also reported to the user via
+ * {@see Formatter::reportCodeProblem()}.
+ *
+ * @api
  */
-final class ControlStructureSpacing implements TokenRule
+final class ControlStructureSpacing implements MultiTokenRule
 {
-    use TokenRuleTrait;
+    use MultiTokenRuleTrait;
 
     public function getPriority(string $method): ?int
     {
-        return 83;
+        switch ($method) {
+            case self::PROCESS_TOKENS:
+                return 83;
+
+            default:
+                return null;
+        }
     }
 
     public function getTokenTypes(): array
@@ -32,86 +38,99 @@ final class ControlStructureSpacing implements TokenRule
         ];
     }
 
-    public function processToken(Token $token): void
+    public function processTokens(array $tokens): void
     {
-        // Ignore the second half of `elseif` expressed as `else if`
-        if ($token->id === T_IF && ($token->_prevCode->id ?? null) === T_ELSE) {
-            return;
-        }
-        if ($token->id === T_ELSE && $token->_nextCode->id === T_IF) {
-            $offset = 3;
-        } elseif ($token->is(TokenType::HAS_STATEMENT_WITH_OPTIONAL_BRACES)) {
-            $offset = 1;
-        } else {
-            $offset = 2;
-        }
-
-        /**
-         * For reference, the following code prints "11" because the T_CLOSE_TAG
-         * terminates the `while` structure:
-         *
-         * ```php
-         * <?php
-         * $i = 0;
-         * while ($i++ < 10)
-         * ?><?php
-         * echo $i;
-         * ```
-         */
-        $body = $token->nextSibling($offset);
-        if ($body->IsNull ||
-                $body->is([T_COLON, T_SEMICOLON, T_OPEN_BRACE, T_CLOSE_TAG])) {
-            return;
-        }
-
-        $token->BodyIsUnenclosed = true;
-
-        if ($token->prev()->id !== T_CLOSE_BRACE || !$token->continuesControlStructure()) {
-            $token->WhitespaceBefore |= WhitespaceType::LINE;
-            $token->WhitespaceMaskPrev |= WhitespaceType::LINE;
-            $token->prev()->WhitespaceMaskNext |= WhitespaceType::LINE;
-        }
-
-        $body->WhitespaceBefore |= WhitespaceType::LINE | WhitespaceType::SPACE;
-        $body->WhitespaceMaskPrev |= WhitespaceType::LINE;
-        $body->WhitespaceMaskPrev &= ~WhitespaceType::BLANK;
-        $body->prev()->WhitespaceMaskNext |= WhitespaceType::LINE;
-
-        $end = null;
-        $continues = false;
-        if ($token->id === T_DO) {
-            $continues = true;
-        } elseif ($token->is([T_IF, T_ELSEIF])) {
-            $end = $body->prevSibling()->nextSiblingOf(T_IF, T_ELSEIF, T_ELSE);
-            if ($end->id === T_IF) {
-                $end = $body->EndStatement;
-            } elseif (!$end->IsNull) {
-                $end = $end->prevCode();
-                $continues = true;
+        foreach ($tokens as $token) {
+            // Ignore the second half of `elseif` expressed as `else if`
+            if ($token->id === T_IF &&
+                    $token->_prevCode &&
+                    $token->_prevCode->id === T_ELSE) {
+                continue;
             }
+
+            if ($token->id === T_ELSE &&
+                    $token->_nextCode->id === T_IF) {
+                $body = $token->_nextSibling->_nextSibling->_nextSibling;
+            } elseif ($this->TypeIndex->HasStatementWithOptionalBraces[$token->id]) {
+                $body = $token->_nextSibling;
+            } else {
+                $body = $token->_nextSibling->_nextSibling;
+            }
+
+            // Ignore enclosed and empty bodies
+            if ($body->id === T_OPEN_BRACE ||
+                    $body->id === T_COLON ||
+                    $body->id === T_SEMICOLON ||
+                    $body->IsStatementTerminator) {
+                continue;
+            }
+
+            $token->BodyIsUnenclosed = true;
+
+            // Add a newline before the token unless it continues a control
+            // structure where the previous body had enclosing braces
+            if (!$token->_prevCode ||
+                    $token->_prevCode->id !== T_CLOSE_BRACE ||
+                    !$token->continuesControlStructure()) {
+                $token->WhitespaceBefore |= WhitespaceType::LINE;
+                $token->WhitespaceMaskPrev |= WhitespaceType::LINE;
+                $token->_prev->WhitespaceMaskNext |= WhitespaceType::LINE;
+            }
+
+            // Add newlines and suppress blank lines before unenclosed bodies
+            $body->WhitespaceBefore |= WhitespaceType::LINE | WhitespaceType::SPACE;
+            $body->WhitespaceMaskPrev |= WhitespaceType::LINE;
+            $body->WhitespaceMaskPrev &= ~WhitespaceType::BLANK;
+            $body->_prev->WhitespaceMaskNext |= WhitespaceType::LINE;
+
+            // Find the last token in the body
+            $end = null;
+            $continues = false;
+            if ($token->id === T_DO) {
+                $continues = true;
+            } elseif ($token->is([T_IF, T_ELSEIF])) {
+                $end = $body->prevSibling()->nextSiblingOf(T_IF, T_ELSEIF, T_ELSE);
+                if ($end->id === T_IF) {
+                    $end = $body->EndStatement;
+                } elseif (!$end->IsNull) {
+                    $end = $end->_prevCode;
+                    $continues = true;
+                }
+            }
+            if (!$end ||
+                    $end->IsNull ||
+                    $end->Index > $body->EndStatement->Index) {
+                $end = $body->pragmaticEndOfExpression()
+                            ->withTerminator();
+            }
+
+            // Use PreIndent to apply indentation that isn't clobbered by
+            // `StandardIndentation`
+            foreach ($body->collect($end) as $t) {
+                $t->PreIndent++;
+            }
+
+            // Add a newline after the body
+            $end->WhitespaceAfter |= WhitespaceType::LINE | WhitespaceType::SPACE;
+            $end->WhitespaceMaskNext |= WhitespaceType::LINE;
+
+            // If the control structure continues, suppress blank lines after
+            // the body
+            if ($continues) {
+                $end->WhitespaceMaskNext &= ~WhitespaceType::BLANK;
+            }
+
+            if (!$this->Formatter->CollectCodeProblems) {
+                continue;
+            }
+
+            $this->Formatter->reportCodeProblem(
+                $this,
+                'Braces not used in %s control structure',
+                $token,
+                $end,
+                $token->getTokenName()
+            );
         }
-
-        if (!$end || $end->IsNull || $end->Index > $body->EndStatement->Index) {
-            $end = $body->pragmaticEndOfExpression(true)->withTerminator();
-        }
-
-        $body->collect($end)
-             // Use PreIndent because StandardIndentation clobbers Indent
-             ->forEach(fn(Token $t) => $t->PreIndent++);
-
-        $end->WhitespaceAfter |= WhitespaceType::LINE | WhitespaceType::SPACE;
-        $end->WhitespaceMaskNext |= WhitespaceType::LINE;
-        if ($continues) {
-            $end->WhitespaceMaskNext &= ~WhitespaceType::BLANK;
-            $end->next()->WhitespaceMaskPrev |= WhitespaceType::LINE;
-        }
-
-        $this->Formatter->reportProblem(
-            $this,
-            'Braces not used in %s control structure',
-            $token,
-            $end,
-            $token->getTokenName()
-        );
     }
 }

--- a/src/Rule/StandardIndentation.php
+++ b/src/Rule/StandardIndentation.php
@@ -26,7 +26,6 @@ final class StandardIndentation implements TokenRule
     {
         if ($token->OpenedBy) {
             $token->Indent = $token->OpenedBy->Indent;
-
             return;
         }
 
@@ -46,7 +45,6 @@ final class StandardIndentation implements TokenRule
             if (!$prev->NewlineAfterPreserved) {
                 $this->mirrorBracket($prev, true);
             }
-
             return;
         }
 

--- a/src/Support/TokenTypeIndex.php
+++ b/src/Support/TokenTypeIndex.php
@@ -191,6 +191,18 @@ class TokenTypeIndex implements IImmutable
      * @readonly
      * @var array<int,bool>
      */
+    public array $HasStatementWithOptionalBraces;
+
+    /**
+     * @readonly
+     * @var array<int,bool>
+     */
+    public array $HasExpressionAndStatementWithOptionalBraces;
+
+    /**
+     * @readonly
+     * @var array<int,bool>
+     */
     public array $NotCode;
 
     /**
@@ -426,6 +438,8 @@ class TokenTypeIndex implements IImmutable
         $this->DeclarationPart = TT::getIndex(...TT::DECLARATION_PART);
         $this->DeclarationPartWithNew = TT::getIndex(...TT::DECLARATION_PART_WITH_NEW);
         $this->HasStatement = TT::getIndex(...TT::HAS_STATEMENT);
+        $this->HasStatementWithOptionalBraces = TT::getIndex(...TT::HAS_STATEMENT_WITH_OPTIONAL_BRACES);
+        $this->HasExpressionAndStatementWithOptionalBraces = TT::getIndex(...TT::HAS_EXPRESSION_AND_STATEMENT_WITH_OPTIONAL_BRACES);
         $this->NotCode = TT::getIndex(...TT::NOT_CODE);
         $this->Visibility = TT::getIndex(...TT::VISIBILITY);
     }

--- a/src/Token/Concern/NavigableTokenTrait.php
+++ b/src/Token/Concern/NavigableTokenTrait.php
@@ -338,6 +338,7 @@ trait NavigableTokenTrait
                         $_prev->nextSiblingOf(T_OPEN_BRACE)->ClosedBy === $token) {
                     $_next = $_prev->_nextSibling;
                     if ($_next->id === T_OPEN_PARENTHESIS ||
+                            $_next->id === T_OPEN_BRACE ||
                             $_next->id === T_EXTENDS ||
                             $_next->id === T_IMPLEMENTS) {
                         $prev = $token;

--- a/tests/fixtures/out.01-default/3rdparty/php-doc/language/control-structures/for/000.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-doc/language/control-structures/for/000.php
@@ -7,7 +7,7 @@ for ($i = 1; $i <= 10; $i++) {
 
 /* example 2 */
 
-for ($i = 1; ; $i++) {
+for ($i = 1;; $i++) {
     if ($i > 10) {
         break;
     }
@@ -17,7 +17,7 @@ for ($i = 1; ; $i++) {
 /* example 3 */
 
 $i = 1;
-for (; ; ) {
+for (;;) {
     if ($i > 10) {
         break;
     }

--- a/tests/fixtures/out.01-default/3rdparty/php-fig/per/10-4.1-extends-and-implements.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-fig/per/10-4.1-extends-and-implements.php
@@ -2,9 +2,9 @@
 
 namespace Vendor\Package;
 
+use OtherVendor\OtherPackage\BazClass;
 use BarClass as Bar;
 use FooClass;
-use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {

--- a/tests/fixtures/out.01-default/3rdparty/php-fig/per/11-4.1-extends-and-implements.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-fig/per/11-4.1-extends-and-implements.php
@@ -2,9 +2,9 @@
 
 namespace Vendor\Package;
 
+use OtherVendor\OtherPackage\BazClass;
 use BarClass as Bar;
 use FooClass;
-use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements
     \ArrayAccess,

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/092-spacing-docblock-class
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/092-spacing-docblock-class
@@ -2,8 +2,8 @@
 
 namespace NS\SNS;
 
-use ONS\A;
 use ONS\A\B;
+use ONS\A;
 
 /**
  * Comment

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/096-use-clause-within-docblocks
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/096-use-clause-within-docblocks
@@ -2,8 +2,8 @@
 
 namespace NS1;
 
-use AA\BB;
 use AA\BB\CC as CC;
+use AA\BB;
 
 class SomeClass
 {

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/097-two-whiles
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/097-two-whiles
@@ -40,8 +40,7 @@ do {
         //lll
         while (true);
         do {
-        }  /* lll */
-        while (true);
+        } /* lll */ while (true);
 
         while (true) {
         }

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/117-multiple-namespaces
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/117-multiple-namespaces
@@ -1,9 +1,9 @@
 <?php
 namespace MyProject;
 
+use Project\Connection;
 use A;
 use C;
-use Project\Connection;
 
 class A
 {

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/374-unused-import-grouped
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/374-unused-import-grouped
@@ -1,9 +1,9 @@
 <?php
-use Acme\Vendor\C;
 use Acme\Vendor\{
     A,
     B
 };
+use Acme\Vendor\C;
 
 class Test
 {

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/401-SortUseNamespace
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/401-SortUseNamespace
@@ -3,11 +3,11 @@
 namespace Laravel\Spark\Repositories;
 
 use Carbon\Carbon;
-use DB;
 use Illuminate\Http\Request;
 use Laravel\Spark\Contracts\Repositories\UserRepository as Contract;
 use Laravel\Spark\InteractsWithSparkHooks;
 use Laravel\Spark\Spark;
+use DB;
 
 class Foo
 {

--- a/tests/fixtures/out.02-aligned/3rdparty/php-doc/language/control-structures/for/000.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-doc/language/control-structures/for/000.php
@@ -7,7 +7,7 @@ for ($i = 1; $i <= 10; $i++) {
 
 /* example 2 */
 
-for ($i = 1; ; $i++) {
+for ($i = 1;; $i++) {
     if ($i > 10) {
         break;
     }
@@ -17,7 +17,7 @@ for ($i = 1; ; $i++) {
 /* example 3 */
 
 $i = 1;
-for (; ; ) {
+for (;;) {
     if ($i > 10) {
         break;
     }

--- a/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/10-4.1-extends-and-implements.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/10-4.1-extends-and-implements.php
@@ -2,9 +2,9 @@
 
 namespace Vendor\Package;
 
+use OtherVendor\OtherPackage\BazClass;
 use BarClass as Bar;
 use FooClass;
-use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {

--- a/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/11-4.1-extends-and-implements.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/11-4.1-extends-and-implements.php
@@ -2,9 +2,9 @@
 
 namespace Vendor\Package;
 
+use OtherVendor\OtherPackage\BazClass;
 use BarClass as Bar;
 use FooClass;
-use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements
     \ArrayAccess,

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/092-spacing-docblock-class
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/092-spacing-docblock-class
@@ -2,8 +2,8 @@
 
 namespace NS\SNS;
 
-use ONS\A;
 use ONS\A\B;
+use ONS\A;
 
 /**
  * Comment

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/096-use-clause-within-docblocks
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/096-use-clause-within-docblocks
@@ -2,8 +2,8 @@
 
 namespace NS1;
 
-use AA\BB;
 use AA\BB\CC as CC;
+use AA\BB;
 
 class SomeClass
 {

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/097-two-whiles
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/097-two-whiles
@@ -40,8 +40,7 @@ do {
         //lll
         while (true);
         do {
-        }  /* lll */
-        while (true);
+        } /* lll */ while (true);
 
         while (true) {
         }

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/117-multiple-namespaces
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/117-multiple-namespaces
@@ -1,9 +1,9 @@
 <?php
 namespace MyProject;
 
+use Project\Connection;
 use A;
 use C;
-use Project\Connection;
 
 class A
 {

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/374-unused-import-grouped
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/374-unused-import-grouped
@@ -1,9 +1,9 @@
 <?php
-use Acme\Vendor\C;
 use Acme\Vendor\{
     A,
     B
 };
+use Acme\Vendor\C;
 
 class Test
 {

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/401-SortUseNamespace
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/401-SortUseNamespace
@@ -3,11 +3,11 @@
 namespace Laravel\Spark\Repositories;
 
 use Carbon\Carbon;
-use DB;
 use Illuminate\Http\Request;
 use Laravel\Spark\Contracts\Repositories\UserRepository as Contract;
 use Laravel\Spark\InteractsWithSparkHooks;
 use Laravel\Spark\Spark;
+use DB;
 
 class Foo
 {

--- a/tests/fixtures/out.03-tab/3rdparty/php-doc/language/control-structures/for/000.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-doc/language/control-structures/for/000.php
@@ -7,7 +7,7 @@ for ($i = 1; $i <= 10; $i++) {
 
 /* example 2 */
 
-for ($i = 1; ; $i++) {
+for ($i = 1;; $i++) {
 	if ($i > 10) {
 		break;
 	}
@@ -17,7 +17,7 @@ for ($i = 1; ; $i++) {
 /* example 3 */
 
 $i = 1;
-for (; ; ) {
+for (;;) {
 	if ($i > 10) {
 		break;
 	}

--- a/tests/fixtures/out.03-tab/3rdparty/php-fig/per/10-4.1-extends-and-implements.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-fig/per/10-4.1-extends-and-implements.php
@@ -2,9 +2,9 @@
 
 namespace Vendor\Package;
 
+use OtherVendor\OtherPackage\BazClass;
 use BarClass as Bar;
 use FooClass;
-use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {

--- a/tests/fixtures/out.03-tab/3rdparty/php-fig/per/11-4.1-extends-and-implements.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-fig/per/11-4.1-extends-and-implements.php
@@ -2,9 +2,9 @@
 
 namespace Vendor\Package;
 
+use OtherVendor\OtherPackage\BazClass;
 use BarClass as Bar;
 use FooClass;
-use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements
 	\ArrayAccess,

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/092-spacing-docblock-class
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/092-spacing-docblock-class
@@ -2,8 +2,8 @@
 
 namespace NS\SNS;
 
-use ONS\A;
 use ONS\A\B;
+use ONS\A;
 
 /**
  * Comment

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/096-use-clause-within-docblocks
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/096-use-clause-within-docblocks
@@ -2,8 +2,8 @@
 
 namespace NS1;
 
-use AA\BB;
 use AA\BB\CC as CC;
+use AA\BB;
 
 class SomeClass
 {

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/097-two-whiles
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/097-two-whiles
@@ -40,8 +40,7 @@ do {
 		//lll
 		while (true);
 		do {
-		}  /* lll */
-		while (true);
+		} /* lll */ while (true);
 
 		while (true) {
 		}

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/117-multiple-namespaces
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/117-multiple-namespaces
@@ -1,9 +1,9 @@
 <?php
 namespace MyProject;
 
+use Project\Connection;
 use A;
 use C;
-use Project\Connection;
 
 class A
 {

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/374-unused-import-grouped
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/374-unused-import-grouped
@@ -1,9 +1,9 @@
 <?php
-use Acme\Vendor\C;
 use Acme\Vendor\{
 	A,
 	B
 };
+use Acme\Vendor\C;
 
 class Test
 {

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/401-SortUseNamespace
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/401-SortUseNamespace
@@ -3,11 +3,11 @@
 namespace Laravel\Spark\Repositories;
 
 use Carbon\Carbon;
-use DB;
 use Illuminate\Http\Request;
 use Laravel\Spark\Contracts\Repositories\UserRepository as Contract;
 use Laravel\Spark\InteractsWithSparkHooks;
 use Laravel\Spark\Spark;
+use DB;
 
 class Foo
 {

--- a/tests/unit/FormatterTest.php
+++ b/tests/unit/FormatterTest.php
@@ -4,6 +4,7 @@ namespace Lkrms\PrettyPHP\Tests;
 
 use Lkrms\Facade\File;
 use Lkrms\Facade\Sys;
+use Lkrms\PrettyPHP\Catalog\ImportSortOrder;
 use Lkrms\PrettyPHP\Rule\AlignArrowFunctions;
 use Lkrms\PrettyPHP\Rule\AlignChains;
 use Lkrms\PrettyPHP\Rule\AlignComments;
@@ -60,10 +61,8 @@ $a,
 $b];
 PHP,
                 ['callback' =>
-                    function (Formatter $formatter): Formatter {
-                        $formatter->SymmetricalBrackets = false;
-                        return $formatter;
-                    }],
+                    fn(Formatter $f) =>
+                        $f->with('SymmetricalBrackets', false)],
             ],
             'empty heredoc' => [
                 <<<'PHP'
@@ -163,6 +162,37 @@ while ($b):
 endwhile;
 else:
 endif;
+PHP,
+            ],
+            'empty statements inside braces' => [
+                <<<'PHP'
+<?php
+function a()
+{
+    ;
+    if ($b) {
+        ;
+        c();
+        if ($d) {
+            e();
+        }
+    }
+    f();
+    g();
+}
+
+PHP,
+                <<<'PHP'
+<?php
+function a()
+{;
+if ($b) {;
+    c();
+if ($d) {
+    e();
+} }
+    f();
+    g(); }
 PHP,
             ],
         ];
@@ -317,7 +347,8 @@ PHP,
                 'skipFilters' => [],
                 'callback' =>
                     fn(Formatter $f) =>
-                        $f->withPsr12Compliance(),
+                        $f->withPsr12Compliance()
+                          ->with('ImportSortOrder', ImportSortOrder::NONE),
             ],
         ];
     }

--- a/tests/unit/Rule/HeredocIndentationTest.php
+++ b/tests/unit/Rule/HeredocIndentationTest.php
@@ -41,10 +41,9 @@ Fugiat magna laborum ut occaecat sit nostrud non eiusmod laboris nisi.
 EOF
 ];
 PHP,
-                ['callback' => function (Formatter $formatter): Formatter {
-                    $formatter->HeredocIndent = HeredocIndent::NONE;
-                    return $formatter;
-                }],
+                ['callback' =>
+                    fn(Formatter $f) =>
+                        $f->with('HeredocIndent', HeredocIndent::NONE)],
             ],
             'LINE' => [
                 <<<'PHP'
@@ -64,10 +63,9 @@ Incididunt in sint sit aliqua pariatur ad.
 EOF;
 };
 PHP,
-                ['callback' => function (Formatter $formatter): Formatter {
-                    $formatter->HeredocIndent = HeredocIndent::LINE;
-                    return $formatter;
-                }],
+                ['callback' =>
+                    fn(Formatter $f) =>
+                        $f->with('HeredocIndent', HeredocIndent::LINE)],
             ],
             'MIXED' => [
                 <<<'PHP'
@@ -91,10 +89,9 @@ $string2 =
 Aliquip mollit elit consectetur nulla laborum minim amet.
 EOF;
 PHP,
-                ['callback' => function (Formatter $formatter): Formatter {
-                    $formatter->HeredocIndent = HeredocIndent::MIXED;
-                    return $formatter;
-                }],
+                ['callback' =>
+                    fn(Formatter $f) =>
+                        $f->with('HeredocIndent', HeredocIndent::MIXED)],
             ],
             'HANGING' => [
                 <<<'PHP'
@@ -118,10 +115,9 @@ $string2 =
 Aliquip mollit elit consectetur nulla laborum minim amet.
 EOF;
 PHP,
-                ['callback' => function (Formatter $formatter): Formatter {
-                    $formatter->HeredocIndent = HeredocIndent::HANGING;
-                    return $formatter;
-                }],
+                ['callback' =>
+                    fn(Formatter $f) =>
+                        $f->with('HeredocIndent', HeredocIndent::HANGING)],
             ],
         ];
     }


### PR DESCRIPTION
- Rework `StatementSpacing` to resolve an issue where empty statements after open braces (e.g. `function () { ; // ...`) disrupt subsequent indentation
- Collapse space after expression delimiters in `for` loops if the next expression is empty
- Fix an issue where anonymous class declarations are not always recognised
- Optimize `ControlStructureSpacing` and `PlaceBraces`
- Improve support for inline comments between control structure tokens

`SortImports`:
- Order imports depth-first by default
- Don't place grouped imports below ungrouped imports when sorting by name

`Formatter`:
- Allow instances to be cloned
- Add `Formatter::with()`
- Make collection of problems optional via the `COLLECT_CODE_PROBLEMS` flag and `$CollectCodeProblems` property, allowing rules to avoid the expense of reporting problems that won't be actioned