### PR TITLE
Tighten criteria for preservation of newlines and blank lines

### DIFF
--- a/.prettyphp
+++ b/.prettyphp
@@ -16,6 +16,5 @@
         "preserve-one-line",
         "strict-lists"
     ],
-    "heredocIndent": "none",
-    "sortImportsBy": "depth"
+    "heredocIndent": "none"
 }

--- a/src/Concern/ExtensionTrait.php
+++ b/src/Concern/ExtensionTrait.php
@@ -23,8 +23,7 @@ trait ExtensionTrait
 
     public function __construct(Formatter $formatter)
     {
-        $this->Formatter = $formatter;
-        $this->TypeIndex = $formatter->TokenTypeIndex;
+        $this->setFormatter($formatter);
     }
 
     public function setFormatter(Formatter $formatter): void

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -709,7 +709,7 @@ final class Formatter implements IReadable
                     }
                     continue 2;
 
-                case T_OPEN_PARENTHESIS:;
+                case T_OPEN_PARENTHESIS:
                     if (!($prev = $parent->_prevCode) ||
                         !(($prev->id === T_CLOSE_BRACE &&
                                 !$prev->isStructuralBrace()) ||

--- a/src/Rule/DeclarationSpacing.php
+++ b/src/Rule/DeclarationSpacing.php
@@ -213,7 +213,7 @@ final class DeclarationSpacing implements MultiTokenRule
                     $token->applyBlankLineBefore(true);
                 }
 
-                continue;;
+                continue;
             }
 
             $token->WhitespaceBefore |= WhitespaceType::LINE;

--- a/src/Rule/StandardWhitespace.php
+++ b/src/Rule/StandardWhitespace.php
@@ -229,7 +229,7 @@ final class StandardWhitespace implements TokenRule
         }
 
         // Add LINE after labels
-        if ($token->id === T_COLON && $token->inLabel()) {
+        if ($token->id === T_COLON && $token->isLabelTerminator()) {
             $token->WhitespaceAfter |= WhitespaceType::LINE;
 
             return;

--- a/src/Rule/StrictLists.php
+++ b/src/Rule/StrictLists.php
@@ -23,7 +23,13 @@ final class StrictLists implements ListRule
 
     public function getPriority(string $method): ?int
     {
-        return 370;
+        switch ($method) {
+            case self::PROCESS_LIST:
+                return 370;
+
+            default:
+                return null;
+        }
     }
 
     public function processList(Token $owner, TokenCollection $items): void

--- a/src/Support/TokenCollection.php
+++ b/src/Support/TokenCollection.php
@@ -76,6 +76,36 @@ final class TokenCollection extends TypedCollection implements Stringable
     }
 
     /**
+     * True if there is a newline before one of the tokens in the collection
+     *
+     */
+    public function tokenHasNewlineBefore(): bool
+    {
+        /** @var Token $token */
+        foreach ($this as $token) {
+            if ($token->hasNewlineBefore()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * True if there is a newline after one of the tokens in the collection
+     *
+     */
+    public function tokenHasNewlineAfter(): bool
+    {
+        /** @var Token $token */
+        foreach ($this as $token) {
+            if ($token->hasNewlineAfter()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * True if any tokens in the collection are separated by one or more line
      * breaks
      *


### PR DESCRIPTION
- Don't preserve newlines after close braces that are non-structural
- Collapse blank lines between list items and in other expression contexts (e.g. `for` loop expressions), including before comments
- If one expression in a `for` loop is at the start of a line, add a newline before the others