### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,14 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
 
+      # Run the phar and man builds separately and together to test each code
+      # path in the build script
       - name: Run build script
         id: run-build-script
         run: |
           scripts/build.sh
           scripts/build.sh man
+          scripts/build.sh man worktree
           cd build/dist
           { printf 'artifact_name=%s-snapshot-phar\n' "${GITHUB_REPOSITORY##*/}" &&
             printf 'artifact_path=%s\n' *.phar | head -n1 &&

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,6 @@ jobs:
           scripts/update-version.sh ${{ github.event.inputs.tag-name || github.ref_name }} || status=$?
           ((!status || status == 2)) || exit "$status"
           ((status)) && draft= || unset draft
-          gh release create ${{ github.event.inputs.tag-name || github.ref_name }} ${draft+--draft} --generate-notes --verify-tag
+          gh release create ${{ github.event.inputs.tag-name || github.ref_name }} ${draft+--draft} ${draft+--generate-notes} --verify-tag
         env:
           GH_TOKEN: ${{ secrets.VSCODE_COMMITTER_TOKEN }}

--- a/scripts/create-PKGBUILD.sh
+++ b/scripts/create-PKGBUILD.sh
@@ -20,7 +20,7 @@ arch=('any')
 license=('MIT')
 url="https://github.com/lkrms/pretty-php"
 depends=('php')
-makedepends=('php-sodium' 'git' 'composer')
+makedepends=('php-sodium' 'git' 'composer' 'pandoc')
 source=("${pkgname}::git+https://github.com/lkrms/pretty-php.git#tag=v${pkgver}")
 sha256sums=('SKIP')
 
@@ -32,7 +32,7 @@ prepare() {
 build() {
     _check_sodium
     cd "${srcdir}/${pkgname}"
-    scripts/build.sh "v${pkgver}"
+    scripts/build.sh man "v${pkgver}"
 }
 
 check() {
@@ -40,21 +40,29 @@ check() {
     local phar
     phar=$(_phar)
     echo "Checking output of \`$phar --version\`"
-    "$phar" --version | grep -F "pretty-php v${pkgver}-"
+    "$phar" --version | grep -F "${pkgname} v${pkgver}-"
 }
 
 package() {
     cd "${srcdir}/${pkgname}"
-    local phar
+    local phar man
     phar=$(_phar)
-    install -Dm755 "$phar" "${pkgdir}/usr/bin/pretty-php"
+    man=$(_man)
+    install -Dm755 "$phar" "${pkgdir}/usr/bin/${pkgname}"
+    install -Dm644 "$man" "${pkgdir}/usr/share/man/man1/${pkgname}.1"
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }
 
 _phar() {
-    local phar=(build/dist/*)
+    local phar=(build/dist/*.phar)
     [[ ${#phar[@]} -eq 1 ]] && [[ -x $phar ]] || return
     printf '%s\n' "$phar"
+}
+
+_man() {
+    local man=(build/dist/*.1)
+    [[ ${#man[@]} -eq 1 ]] && [[ -r $man ]] || return
+    printf '%s\n' "$man"
 }
 
 _check_sodium() {


### PR DESCRIPTION
- Don't generate release notes unless adding a draft
- Generate man page in Arch Linux PKGBUILD
- Update build script so man pages refer to `pretty-php`, not `pretty-php.phar`, and remove unnecessary `git clone` step if running in a CI environment