### PR TITLE
Add `StrictExpressions` rule and related changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "lkrms/util": "^0.20.58",
+        "lkrms/util": "^0.20.59",
         "sebastian/diff": "^4 || ^5"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a0ca16305f052a6b286d996d4c69b86",
+    "content-hash": "676fd0c16a4a5049da74f3fd8e0f9179",
     "packages": [
         {
             "name": "filp/whoops",
@@ -122,16 +122,16 @@
         },
         {
             "name": "lkrms/util",
-            "version": "v0.20.58",
+            "version": "v0.20.59",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lkrms/php-util.git",
-                "reference": "a6d012881d2e44d577811a0a6aa74f53a3a3bed7"
+                "reference": "0686702eaf9ace63c95eb34bd2ad741a3cbf8f84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lkrms/php-util/zipball/a6d012881d2e44d577811a0a6aa74f53a3a3bed7",
-                "reference": "a6d012881d2e44d577811a0a6aa74f53a3a3bed7",
+                "url": "https://api.github.com/repos/lkrms/php-util/zipball/0686702eaf9ace63c95eb34bd2ad741a3cbf8f84",
+                "reference": "0686702eaf9ace63c95eb34bd2ad741a3cbf8f84",
                 "shasum": ""
             },
             "require": {
@@ -182,9 +182,9 @@
             "description": "A lightweight PHP toolkit for expressive backend/CLI apps",
             "support": {
                 "issues": "https://github.com/lkrms/php-util/issues",
-                "source": "https://github.com/lkrms/php-util/tree/v0.20.58"
+                "source": "https://github.com/lkrms/php-util/tree/v0.20.59"
             },
-            "time": "2023-09-14T03:59:47+00:00"
+            "time": "2023-09-16T01:04:54+00:00"
         },
         {
             "name": "psr/container",

--- a/docs/PSR-12.md
+++ b/docs/PSR-12.md
@@ -12,6 +12,7 @@ default style is not quite 100% compliant.
 
 Enabled:
 
+- `StrictExpressions`
 - `StrictLists`
 - `SortImports`
 - `DeclarationSpacing`
@@ -61,6 +62,34 @@ namespace Vendor\Package;
 > namespace Vendor\Package;
 > ```
 
+### Control structure expressions
+
+Control structure expressions that break over multiple lines are moved to the
+start of a line:
+
+```php
+<?php
+// Before
+if ($foo || $bar) {
+    baz();
+}
+if ($foo ||
+        $bar) {
+    baz();
+}
+
+// After
+if ($foo || $bar) {
+    baz();
+}
+if (
+    $foo
+    || $bar
+) {
+    baz();
+}
+```
+
 ### Heredocs and nowdocs
 
 Newlines before heredocs and nowdocs are suppressed, and unconditional heredoc
@@ -79,8 +108,8 @@ $baz = <<<EOF
     EOF;
 ```
 
-> `pretty-php`'s default style does not apply indentation to heredocs in contexts
-> where there is no ambiguity without it:
+> `pretty-php`'s default style does not apply indentation to heredocs in
+> contexts where there is no ambiguity without it:
 >
 > ```php
 > $foo = <<<EOF

--- a/src/Command/FormatPhp.php
+++ b/src/Command/FormatPhp.php
@@ -38,6 +38,7 @@ use Lkrms\PrettyPHP\Rule\DeclarationSpacing;
 use Lkrms\PrettyPHP\Rule\NormaliseStrings;
 use Lkrms\PrettyPHP\Rule\PreserveLineBreaks;
 use Lkrms\PrettyPHP\Rule\PreserveOneLineStatements;
+use Lkrms\PrettyPHP\Rule\StrictExpressions;
 use Lkrms\PrettyPHP\Rule\StrictLists;
 use Lkrms\PrettyPHP\Support\TokenTypeIndex;
 use Lkrms\PrettyPHP\Token\Token;
@@ -72,6 +73,7 @@ class FormatPhp extends CliCommand
         'align-data' => AlignData::class,
         'align-lists' => AlignLists::class,
         'blank-before-return' => BlankLineBeforeReturn::class,
+        'strict-expressions' => StrictExpressions::class,
         'strict-lists' => StrictLists::class,
         'preserve-one-line' => PreserveOneLineStatements::class,
     ];
@@ -1004,6 +1006,7 @@ EOF,
                         AlignLists::class,
                     ];
                     $add = [
+                        StrictExpressions::class,
                         StrictLists::class,
                     ];
                     $this->SkipRules = array_diff($this->SkipRules, $unskip, $skip);

--- a/src/Concern/ExtensionTrait.php
+++ b/src/Concern/ExtensionTrait.php
@@ -29,7 +29,7 @@ trait ExtensionTrait
     public function setFormatter(Formatter $formatter): void
     {
         $this->Formatter = $formatter;
-        $this->TypeIndex = $formatter->TokenTypeIndex;
+        $this->TypeIndex = &$formatter->TokenTypeIndex;
     }
 
     public function reset(): void {}

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -56,6 +56,7 @@ use Lkrms\PrettyPHP\Rule\ProtectStrings;
 use Lkrms\PrettyPHP\Rule\StandardIndentation;
 use Lkrms\PrettyPHP\Rule\StandardWhitespace;
 use Lkrms\PrettyPHP\Rule\StatementSpacing;
+use Lkrms\PrettyPHP\Rule\StrictExpressions;
 use Lkrms\PrettyPHP\Rule\StrictLists;
 use Lkrms\PrettyPHP\Rule\SwitchIndentation;
 use Lkrms\PrettyPHP\Rule\SymmetricalBrackets;
@@ -205,7 +206,7 @@ final class Formatter implements IReadable
     public const DEFAULT_RULES = [
         ...self::MANDATORY_RULES,
         NormaliseStrings::class,    // processToken  (60)
-        PreserveLineBreaks::class,  // processToken  (93)
+        PreserveLineBreaks::class,  // processToken  (93), callback (100)
         DeclarationSpacing::class,  // processToken (620)
     ];
 
@@ -215,6 +216,7 @@ final class Formatter implements IReadable
     public const ADDITIONAL_RULES = [
         PreserveOneLineStatements::class,  // processToken  (95)
         BlankLineBeforeReturn::class,      // processToken  (97)
+        StrictExpressions::class,          // processToken  (98)
         Laravel::class,                    // processToken (100)
         Symfony::class,                    // processToken (100), processList (100)
         WordPress::class,                  // processToken (100)

--- a/src/Rule/StrictExpressions.php
+++ b/src/Rule/StrictExpressions.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Rule;
+
+use Lkrms\PrettyPHP\Catalog\WhitespaceType;
+use Lkrms\PrettyPHP\Rule\Concern\MultiTokenRuleTrait;
+use Lkrms\PrettyPHP\Rule\Contract\MultiTokenRule;
+
+/**
+ * If a control structure expression breaks over multiple lines, add newlines
+ * before and after it
+ *
+ * Necessary for PSR-12 compliance.
+ *
+ * @api
+ */
+final class StrictExpressions implements MultiTokenRule
+{
+    use MultiTokenRuleTrait;
+
+    public function getPriority(string $method): ?int
+    {
+        switch ($method) {
+            case self::PROCESS_TOKENS:
+                return 98;
+
+            default:
+                return null;
+        }
+    }
+
+    public function getTokenTypes(): array
+    {
+        return [
+            T_IF,
+            T_ELSEIF,
+            T_SWITCH,
+            T_WHILE,
+            T_FOR,
+            T_FOREACH,
+        ];
+    }
+
+    public function getRequiresSortedTokens(): bool
+    {
+        return false;
+    }
+
+    public function processTokens(array $tokens): void
+    {
+        foreach ($tokens as $token) {
+            $first = $token->_nextCode;
+            if ($first->hasNewlineAfter()) {
+                continue;
+            }
+            $last = $first->ClosedBy;
+            if ($first->collect($last)->hasNewline()) {
+                $first->WhitespaceAfter |= WhitespaceType::LINE;
+                $first->WhitespaceMaskNext |= WhitespaceType::LINE;
+                $first->_nextCode->WhitespaceMaskPrev |= WhitespaceType::LINE;
+                $last->WhitespaceBefore |= WhitespaceType::LINE;
+                $last->WhitespaceMaskPrev |= WhitespaceType::LINE;
+                $last->_prevCode->WhitespaceMaskNext |= WhitespaceType::LINE;
+            }
+        }
+    }
+}

--- a/src/Support/TokenTypeIndex.php
+++ b/src/Support/TokenTypeIndex.php
@@ -215,7 +215,15 @@ class TokenTypeIndex implements IImmutable
      * @readonly
      * @var array<int,bool>
      */
+    public array $OperatorLogicalExceptNot;
+
+    /**
+     * @readonly
+     * @var array<int,bool>
+     */
     public array $Visibility;
+
+    public bool $OperatorsAreMixed = true;
 
     public function __construct()
     {
@@ -457,6 +465,7 @@ class TokenTypeIndex implements IImmutable
         $this->HasStatementWithOptionalBraces = TT::getIndex(...TT::HAS_STATEMENT_WITH_OPTIONAL_BRACES);
         $this->HasExpressionAndStatementWithOptionalBraces = TT::getIndex(...TT::HAS_EXPRESSION_AND_STATEMENT_WITH_OPTIONAL_BRACES);
         $this->NotCode = TT::getIndex(...TT::NOT_CODE);
+        $this->OperatorLogicalExceptNot = TT::getIndex(...TT::OPERATOR_LOGICAL_EXCEPT_NOT);
         $this->Visibility = TT::getIndex(...TT::VISIBILITY);
     }
 
@@ -484,7 +493,8 @@ class TokenTypeIndex implements IImmutable
         );
 
         return $this->with('PreserveNewlineBefore', $preserveBefore)
-                    ->with('PreserveNewlineAfter', $preserveAfter);
+                    ->with('PreserveNewlineAfter', $preserveAfter)
+                    ->with('OperatorsAreMixed', false);
     }
 
     /**
@@ -516,7 +526,8 @@ class TokenTypeIndex implements IImmutable
         );
 
         return $this->with('PreserveNewlineBefore', $preserveBefore)
-                    ->with('PreserveNewlineAfter', $preserveAfter);
+                    ->with('PreserveNewlineAfter', $preserveAfter)
+                    ->with('OperatorsAreMixed', false);
     }
 
     public static function create(): TokenTypeIndex

--- a/tests/fixtures/in/standalone/control-structure-expressions.php
+++ b/tests/fixtures/in/standalone/control-structure-expressions.php
@@ -1,0 +1,66 @@
+<?php
+if ($foo) {
+    baz();
+} elseif ($qux) {
+    quux();
+}
+if ($foo ||
+        $bar) {
+    baz();
+} elseif ($foo &&
+        $qux) {
+    quux();
+}
+switch ($foo) {
+    default:
+        baz();
+        break;
+}
+switch ($foo ||
+        $bar) {
+    default:
+        baz();
+        break;
+}
+while ($foo) {
+    baz();
+}
+while ($foo ||
+        $bar) {
+    baz();
+}
+do {
+    baz();
+} while ($foo);
+do {
+    baz();
+} while ($foo ||
+    $bar);
+for (;;) {
+    baz($i);
+}
+for (;
+    ;
+) {
+    baz($i);
+}
+for ($i = 0; $i < 10; $i++) {
+    baz($i);
+}
+for ($i = 0;
+    $i < 10;
+    $i++) {
+    baz($i);
+}
+for ($i = 0, $j = 0;
+    $i < 10;
+    $i++) {
+    baz($i);
+}
+foreach ($foo as $bar) {
+    baz($bar);
+}
+foreach ($foo
+        + $bar as $baz) {
+    qux($baz);
+}

--- a/tests/fixtures/out.01-default/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
@@ -1,13 +1,13 @@
 <?php
 
 if (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
     // if body
 } elseif (
-    $expr3 &&
-    $expr4
+    $expr3
+    && $expr4
 ) {
     // elseif body
 }

--- a/tests/fixtures/out.01-default/3rdparty/php-fig/per/36-5.2-switch-case-match.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-fig/per/36-5.2-switch-case-match.php
@@ -1,8 +1,8 @@
 <?php
 
 switch (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
         // structure body
 }

--- a/tests/fixtures/out.01-default/3rdparty/php-fig/per/39-5.3-while-do-while.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-fig/per/39-5.3-while-do-while.php
@@ -1,8 +1,8 @@
 <?php
 
 while (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
     // structure body
 }

--- a/tests/fixtures/out.01-default/3rdparty/php-fig/per/41-5.3-while-do-while.php
+++ b/tests/fixtures/out.01-default/3rdparty/php-fig/per/41-5.3-while-do-while.php
@@ -3,6 +3,6 @@
 do {
     // structure body;
 } while (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 );

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/195-several-spacing-issues
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/195-several-spacing-issues
@@ -9,7 +9,7 @@ for ($index = 10; 0 <= $index; --$index) {
 }
 
 if (
-    !$conditions ||
-    !($anotherCondition || $someCondition)
+    !$conditions
+    || !($anotherCondition || $someCondition)
 ) {
 }

--- a/tests/fixtures/out.01-default/3rdparty/phpfmt/346-autosemicolon-conditions
+++ b/tests/fixtures/out.01-default/3rdparty/phpfmt/346-autosemicolon-conditions
@@ -2,8 +2,8 @@
 //passes: AutoSemicolon
 
 if (
-    f() &&
-    e()
+    f()
+    && e()
 ) {
     //
 }

--- a/tests/fixtures/out.01-default/standalone/control-structure-expressions.php
+++ b/tests/fixtures/out.01-default/standalone/control-structure-expressions.php
@@ -1,0 +1,66 @@
+<?php
+if ($foo) {
+    baz();
+} elseif ($qux) {
+    quux();
+}
+if ($foo ||
+        $bar) {
+    baz();
+} elseif ($foo &&
+        $qux) {
+    quux();
+}
+switch ($foo) {
+    default:
+        baz();
+        break;
+}
+switch ($foo ||
+        $bar) {
+    default:
+        baz();
+        break;
+}
+while ($foo) {
+    baz();
+}
+while ($foo ||
+        $bar) {
+    baz();
+}
+do {
+    baz();
+} while ($foo);
+do {
+    baz();
+} while ($foo ||
+    $bar);
+for (;;) {
+    baz($i);
+}
+for (;
+    ;
+) {
+    baz($i);
+}
+for ($i = 0; $i < 10; $i++) {
+    baz($i);
+}
+for ($i = 0;
+    $i < 10;
+    $i++) {
+    baz($i);
+}
+for ($i = 0, $j = 0;
+    $i < 10;
+    $i++) {
+    baz($i);
+}
+foreach ($foo as $bar) {
+    baz($bar);
+}
+foreach ($foo
+        + $bar as $baz) {
+    qux($baz);
+}

--- a/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
@@ -1,13 +1,13 @@
 <?php
 
 if (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
     // if body
 } elseif (
-    $expr3 &&
-    $expr4
+    $expr3
+    && $expr4
 ) {
     // elseif body
 }

--- a/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/36-5.2-switch-case-match.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/36-5.2-switch-case-match.php
@@ -1,8 +1,8 @@
 <?php
 
 switch (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
         // structure body
 }

--- a/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/39-5.3-while-do-while.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/39-5.3-while-do-while.php
@@ -1,8 +1,8 @@
 <?php
 
 while (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
     // structure body
 }

--- a/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/41-5.3-while-do-while.php
+++ b/tests/fixtures/out.02-aligned/3rdparty/php-fig/per/41-5.3-while-do-while.php
@@ -3,6 +3,6 @@
 do {
     // structure body;
 } while (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 );

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/195-several-spacing-issues
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/195-several-spacing-issues
@@ -9,7 +9,7 @@ for ($index = 10; 0 <= $index; --$index) {
 }
 
 if (
-    !$conditions ||
-    !($anotherCondition || $someCondition)
+    !$conditions
+    || !($anotherCondition || $someCondition)
 ) {
 }

--- a/tests/fixtures/out.02-aligned/3rdparty/phpfmt/346-autosemicolon-conditions
+++ b/tests/fixtures/out.02-aligned/3rdparty/phpfmt/346-autosemicolon-conditions
@@ -2,8 +2,8 @@
 //passes: AutoSemicolon
 
 if (
-    f() &&
-    e()
+    f()
+    && e()
 ) {
     //
 }

--- a/tests/fixtures/out.02-aligned/standalone/control-structure-expressions.php
+++ b/tests/fixtures/out.02-aligned/standalone/control-structure-expressions.php
@@ -1,0 +1,66 @@
+<?php
+if ($foo) {
+    baz();
+} elseif ($qux) {
+    quux();
+}
+if ($foo ||
+        $bar) {
+    baz();
+} elseif ($foo &&
+        $qux) {
+    quux();
+}
+switch ($foo) {
+    default:
+        baz();
+        break;
+}
+switch ($foo ||
+        $bar) {
+    default:
+        baz();
+        break;
+}
+while ($foo) {
+    baz();
+}
+while ($foo ||
+        $bar) {
+    baz();
+}
+do {
+    baz();
+} while ($foo);
+do {
+    baz();
+} while ($foo ||
+    $bar);
+for (;;) {
+    baz($i);
+}
+for (;
+    ;
+) {
+    baz($i);
+}
+for ($i = 0; $i < 10; $i++) {
+    baz($i);
+}
+for ($i = 0;
+    $i < 10;
+    $i++) {
+    baz($i);
+}
+for ($i = 0, $j = 0;
+    $i < 10;
+    $i++) {
+    baz($i);
+}
+foreach ($foo as $bar) {
+    baz($bar);
+}
+foreach ($foo
+        + $bar as $baz) {
+    qux($baz);
+}

--- a/tests/fixtures/out.03-tab/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
@@ -1,13 +1,13 @@
 <?php
 
 if (
-	$expr1 &&
-	$expr2
+	$expr1
+	&& $expr2
 ) {
 	// if body
 } elseif (
-	$expr3 &&
-	$expr4
+	$expr3
+	&& $expr4
 ) {
 	// elseif body
 }

--- a/tests/fixtures/out.03-tab/3rdparty/php-fig/per/36-5.2-switch-case-match.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-fig/per/36-5.2-switch-case-match.php
@@ -1,8 +1,8 @@
 <?php
 
 switch (
-	$expr1 &&
-	$expr2
+	$expr1
+	&& $expr2
 ) {
 		// structure body
 }

--- a/tests/fixtures/out.03-tab/3rdparty/php-fig/per/39-5.3-while-do-while.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-fig/per/39-5.3-while-do-while.php
@@ -1,8 +1,8 @@
 <?php
 
 while (
-	$expr1 &&
-	$expr2
+	$expr1
+	&& $expr2
 ) {
 	// structure body
 }

--- a/tests/fixtures/out.03-tab/3rdparty/php-fig/per/41-5.3-while-do-while.php
+++ b/tests/fixtures/out.03-tab/3rdparty/php-fig/per/41-5.3-while-do-while.php
@@ -3,6 +3,6 @@
 do {
 	// structure body;
 } while (
-	$expr1 &&
-	$expr2
+	$expr1
+	&& $expr2
 );

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/195-several-spacing-issues
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/195-several-spacing-issues
@@ -9,7 +9,7 @@ for ($index = 10; 0 <= $index; --$index) {
 }
 
 if (
-	!$conditions ||
-	!($anotherCondition || $someCondition)
+	!$conditions
+	|| !($anotherCondition || $someCondition)
 ) {
 }

--- a/tests/fixtures/out.03-tab/3rdparty/phpfmt/346-autosemicolon-conditions
+++ b/tests/fixtures/out.03-tab/3rdparty/phpfmt/346-autosemicolon-conditions
@@ -2,8 +2,8 @@
 //passes: AutoSemicolon
 
 if (
-	f() &&
-	e()
+	f()
+	&& e()
 ) {
 	//
 }

--- a/tests/fixtures/out.03-tab/standalone/control-structure-expressions.php
+++ b/tests/fixtures/out.03-tab/standalone/control-structure-expressions.php
@@ -1,0 +1,66 @@
+<?php
+if ($foo) {
+	baz();
+} elseif ($qux) {
+	quux();
+}
+if ($foo ||
+		$bar) {
+	baz();
+} elseif ($foo &&
+		$qux) {
+	quux();
+}
+switch ($foo) {
+	default:
+		baz();
+		break;
+}
+switch ($foo ||
+		$bar) {
+	default:
+		baz();
+		break;
+}
+while ($foo) {
+	baz();
+}
+while ($foo ||
+		$bar) {
+	baz();
+}
+do {
+	baz();
+} while ($foo);
+do {
+	baz();
+} while ($foo ||
+	$bar);
+for (;;) {
+	baz($i);
+}
+for (;
+	;
+) {
+	baz($i);
+}
+for ($i = 0; $i < 10; $i++) {
+	baz($i);
+}
+for ($i = 0;
+	$i < 10;
+	$i++) {
+	baz($i);
+}
+for ($i = 0, $j = 0;
+	$i < 10;
+	$i++) {
+	baz($i);
+}
+foreach ($foo as $bar) {
+	baz($bar);
+}
+foreach ($foo
+		+ $bar as $baz) {
+	qux($baz);
+}

--- a/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
+++ b/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/34-5.1-if-elseif-else.php
@@ -1,13 +1,13 @@
 <?php
 
 if (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
     // if body
 } elseif (
-    $expr3 &&
-    $expr4
+    $expr3
+    && $expr4
 ) {
     // elseif body
 }

--- a/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/36-5.2-switch-case-match.php
+++ b/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/36-5.2-switch-case-match.php
@@ -1,8 +1,8 @@
 <?php
 
 switch (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
         // structure body
 }

--- a/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/39-5.3-while-do-while.php
+++ b/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/39-5.3-while-do-while.php
@@ -1,8 +1,8 @@
 <?php
 
 while (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 ) {
     // structure body
 }

--- a/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/41-5.3-while-do-while.php
+++ b/tests/fixtures/out.04-psr12/3rdparty/php-fig/per/41-5.3-while-do-while.php
@@ -3,6 +3,6 @@
 do {
     // structure body;
 } while (
-    $expr1 &&
-    $expr2
+    $expr1
+    && $expr2
 );

--- a/tests/fixtures/out.04-psr12/standalone/class-anonymous-01.php
+++ b/tests/fixtures/out.04-psr12/standalone/class-anonymous-01.php
@@ -1,0 +1,35 @@
+<?php
+
+$a = new class extends B implements C, D, E {};
+
+$a = new class extends B implements
+    C,
+    D,
+    E {};
+
+$a = new class extends B implements C, D, E {
+    function f(string $h, int $i, $j) {}
+
+    function g($k) {}
+
+    function z() {}
+};
+
+$a = new class extends B implements
+    C,
+    D,
+    E
+{
+    function f(string $h, int $i, $j)
+    {
+        $this->l($h, $i);
+        $j();
+    }
+
+    function g($k)
+    {
+        echo $k;
+    }
+
+    function z() {}
+};

--- a/tests/fixtures/out.04-psr12/standalone/class-anonymous-attributes-01.php
+++ b/tests/fixtures/out.04-psr12/standalone/class-anonymous-attributes-01.php
@@ -1,0 +1,51 @@
+<?php
+
+$a = new
+    #[AttrA]
+    class extends B implements C, D, E {};
+
+$a = new
+    #[AttrB(true)]
+    #[AttrC(101, Types::ANON_CLASS)]
+    #[AttrD()]
+    class extends B implements
+        C,
+        D,
+        E {};
+
+$a = new
+    #[AttrE]
+    class extends B implements C, D, E
+    {
+        #[AttrF(true)]
+        #[AttrG(102, Types::FUNC)]
+        function f(string $h, int $i, $j) {}
+
+        #[AttrH]
+        function g($k) {}
+    };
+
+$a = new
+    #[AttrI(true)]
+    #[AttrJ(101, Types::ANON_CLASS)]
+    #[AttrK()]
+    class extends B implements
+        C,
+        D,
+        E
+    {
+        #[AttrL(true)]
+        #[AttrM(102, Types::FUNC)]
+        function f(#[AttrN(true), Attr(103, Types::PARAM)] #[AttrO()] string $h, #[AttrP] int $i, $j)
+        {
+            $this->l($h, $i);
+            $j();
+        }
+
+        function g(#[AttrQ(null)] $k)
+        {
+            echo $k;
+        }
+
+        function z(#[AttrY] $x) {}
+    };

--- a/tests/fixtures/out.04-psr12/standalone/class-anonymous-attributes-02.php
+++ b/tests/fixtures/out.04-psr12/standalone/class-anonymous-attributes-02.php
@@ -1,0 +1,51 @@
+<?php
+
+new
+    #[AttrA]
+    class extends B implements C, D, E {};
+
+new
+    #[AttrB(true)]
+    #[AttrC(101, Types::ANON_CLASS)]
+    #[AttrD()]
+    class extends B implements
+        C,
+        D,
+        E {};
+
+new
+    #[AttrE]
+    class extends B implements C, D, E
+    {
+        #[AttrF(true)]
+        #[AttrG(102, Types::FUNC)]
+        function f(string $h, int $i, $j) {}
+
+        #[AttrH]
+        function g($k) {}
+    };
+
+new
+    #[AttrI(true)]
+    #[AttrJ(101, Types::ANON_CLASS)]
+    #[AttrK()]
+    class extends B implements
+        C,
+        D,
+        E
+    {
+        #[AttrL(true)]
+        #[AttrM(102, Types::FUNC)]
+        function f(#[AttrN(true), Attr(103, Types::PARAM)] #[AttrO()] string $h, #[AttrP] int $i, $j)
+        {
+            $this->l($h, $i);
+            $j();
+        }
+
+        function g(#[AttrQ(null)] $k)
+        {
+            echo $k;
+        }
+
+        function z(#[AttrY] $x) {}
+    };

--- a/tests/fixtures/out.04-psr12/standalone/class-attributes-01.php
+++ b/tests/fixtures/out.04-psr12/standalone/class-attributes-01.php
@@ -1,0 +1,54 @@
+<?php
+
+#[AttrA]
+class A1 extends B implements C, D, E {}
+
+#[AttrB(true)]
+#[AttrC(101, Types::ANON_CLASS)]
+#[AttrD()]
+class A2 extends B implements
+    C,
+    D,
+    E {}
+
+#[AttrE]
+class A3 extends B implements C, D, E
+{
+    #[AttrF(true)]
+    #[AttrG(102, Types::FUNC)]
+    function f(string $h, int $i, $j) {}
+
+    #[AttrH]
+    function g($k) {}
+}
+
+#[AttrI(true)]
+#[AttrJ(101, Types::ANON_CLASS)]
+#[AttrK()]
+class A4 extends B implements
+    C,
+    D,
+    E
+{
+    #[AttrL(true)]
+    #[AttrM(102, Types::FUNC)]
+    function f(#[AttrN(true), Attr(103, Types::PARAM)] #[AttrO()] string $h, #[AttrP] int $i, $j = [
+        '*'
+    ])
+    {
+        $this->l($h, $i);
+        $j();
+    }
+
+    function g(
+        #[AttrQ(null)]
+        $k
+    ) {
+        echo $k;
+    }
+
+    function z(
+        #[AttrY]
+        $x
+    ) {}
+}

--- a/tests/fixtures/out.04-psr12/standalone/control-structure-expressions.php
+++ b/tests/fixtures/out.04-psr12/standalone/control-structure-expressions.php
@@ -1,0 +1,83 @@
+<?php
+if ($foo) {
+    baz();
+} elseif ($qux) {
+    quux();
+}
+if (
+    $foo
+    || $bar
+) {
+    baz();
+} elseif (
+    $foo
+    && $qux
+) {
+    quux();
+}
+switch ($foo) {
+    default:
+        baz();
+        break;
+}
+switch (
+    $foo
+    || $bar
+) {
+    default:
+        baz();
+        break;
+}
+while ($foo) {
+    baz();
+}
+while (
+    $foo
+    || $bar
+) {
+    baz();
+}
+do {
+    baz();
+} while ($foo);
+do {
+    baz();
+} while (
+    $foo
+    || $bar
+);
+for (;;) {
+    baz($i);
+}
+for (
+    ;
+    ;
+) {
+    baz($i);
+}
+for ($i = 0; $i < 10; $i++) {
+    baz($i);
+}
+for (
+    $i = 0;
+    $i < 10;
+    $i++
+) {
+    baz($i);
+}
+for (
+    $i = 0, $j = 0;
+    $i < 10;
+    $i++
+) {
+    baz($i);
+}
+foreach ($foo as $bar) {
+    baz($bar);
+}
+foreach (
+    $foo
+    + $bar as $baz
+) {
+    qux($baz);
+}

--- a/tests/fixtures/out.04-psr12/standalone/match-01.php
+++ b/tests/fixtures/out.04-psr12/standalone/match-01.php
@@ -1,0 +1,20 @@
+<?php
+
+$result = match (true) {
+    str_contains($text, 'Welcome') ||
+        str_contains($text, 'Hello'),
+    str_contains($text, 'Hi') || str_contains($text, "G'day") => 'en',
+
+    str_contains($text, 'Bienvenue') ||
+        str_contains($text, 'Bonjour') => 'fr'
+};
+
+$result = match (true) {
+    $senior,
+    $age >= 65 => 'senior',
+    $adult,
+    $age >= 25 => 'adult',
+    $youngAdult,
+    $age >= 18 => 'young adult',
+    default => 'kid'
+};

--- a/tests/unit/FormatterTest.php
+++ b/tests/unit/FormatterTest.php
@@ -10,6 +10,7 @@ use Lkrms\PrettyPHP\Rule\AlignComments;
 use Lkrms\PrettyPHP\Rule\AlignData;
 use Lkrms\PrettyPHP\Rule\AlignLists;
 use Lkrms\PrettyPHP\Rule\AlignTernaryOperators;
+use Lkrms\PrettyPHP\Rule\StrictExpressions;
 use Lkrms\PrettyPHP\Rule\StrictLists;
 use Lkrms\PrettyPHP\Formatter;
 use Generator;
@@ -270,7 +271,9 @@ PHP,
         // - files with no extension, and
         // - either of the above with a .fails extension
         $files = File::find(
-            $format === '04-psr12' ? $inDir . '/3rdparty/php-fig' : $inDir,
+            $format === '04-psr12'
+                ? [$inDir . '/3rdparty/php-fig', $inDir . '/standalone']
+                : $inDir,
             null,
             '/(\.php|\/[^.\/]+)(\.fails)?$/'
         );
@@ -341,6 +344,7 @@ PHP,
                 'tabSize' => 4,
                 'skipRules' => [],
                 'addRules' => [
+                    StrictExpressions::class,
                     StrictLists::class,
                 ],
                 'skipFilters' => [],


### PR DESCRIPTION
- Assign `TypeIndex` to rules and filters by reference so changes made to cloned `Formatter` instances are applied
- Improve `PreserveLineBreaks` heuristics to fix an issue where leading operators remain at the end of a line when followed by `!` on the next line
- Move logical operators to the start of the line in contexts where hanging indentation will not be applied
- Update tests