### PR TITLE
Improve ternary and null coalescing operator indentation

### DIFF
--- a/src/Rule/PreserveLineBreaks.php
+++ b/src/Rule/PreserveLineBreaks.php
@@ -103,7 +103,7 @@ final class PreserveLineBreaks implements MultiTokenRule
         }
 
         // Treat `?:` as one operator
-        if ($token->IsTernaryOperator && $token->TernaryOperator1 === $prev) {
+        if ($token->TernaryOperator1 === $prev) {
             return false;
         }
 
@@ -156,7 +156,7 @@ final class PreserveLineBreaks implements MultiTokenRule
         }
 
         // Treat `?:` as one operator
-        if ($token->IsTernaryOperator && $token->TernaryOperator2 === $next) {
+        if ($token->TernaryOperator2 === $next) {
             return false;
         }
 

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -849,8 +849,7 @@ class Token extends PhpToken implements JsonSerializable
         $ternary1 =
             $this->prevSiblings()
                  ->find(fn(Token $t) =>
-                            $t->IsTernaryOperator &&
-                                $t === $t->TernaryOperator1);
+                            $t === $t->TernaryOperator1);
         if ($ternary1 && $ternary1->TernaryOperator2->Index > $this->Index) {
             return $ternary1->_nextCode->_pragmaticStartOfExpression($this);
         }
@@ -1021,8 +1020,7 @@ class Token extends PhpToken implements JsonSerializable
         // the last token before `:`
         $current = $this;
         while ($current = $current->_prevSibling) {
-            if ($current->IsTernaryOperator &&
-                    $current === $current->TernaryOperator1) {
+            if ($current === $current->TernaryOperator1) {
                 if ($current->TernaryOperator2->Index > $this->Index) {
                     return $current->TernaryOperator2->_prevCode;
                 }

--- a/tests/fixtures/out.02-aligned/issues/0015-hanging-indentation.php
+++ b/tests/fixtures/out.02-aligned/issues/0015-hanging-indentation.php
@@ -6,12 +6,12 @@ class A
     protected function c()
     {
         return $this->b
-            ?? ($this->b = implode(
-                ':', ['a',
-                      'b',
-                      'c',
-                      'd',
-                      'e']
-            ));
+                   ?? ($this->b = implode(
+                       ':', ['a',
+                             'b',
+                             'c',
+                             'd',
+                             'e']
+                   ));
     }
 }

--- a/tests/unit/Rule/AlignTernaryOperatorsTest.php
+++ b/tests/unit/Rule/AlignTernaryOperatorsTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Tests\Rule;
+
+use Lkrms\PrettyPHP\Rule\AlignTernaryOperators;
+
+final class AlignTernaryOperatorsTest extends \Lkrms\PrettyPHP\Tests\TestCase
+{
+    /**
+     * @dataProvider outputProvider
+     */
+    public function testOutput(string $expected, string $code): void
+    {
+        $this->assertCodeFormatIs($expected, $code, [AlignTernaryOperators::class]);
+    }
+
+    /**
+     * @return array<array{string,string}>
+     */
+    public static function outputProvider(): array
+    {
+        return [
+            [
+                <<<'PHP'
+<?php
+$alpha = $bravo
+             ?? $charlie
+             ?: $delta
+             ?? $echo
+             ?: $foxtrot;
+$alpha =
+    $bravo
+        ?? $charlie
+        ?: $delta
+        ?? $echo
+        ?: $foxtrot;
+
+PHP,
+                <<<'PHP'
+<?php
+$alpha = $bravo
+?? $charlie
+?: $delta
+?? $echo
+?: $foxtrot;
+$alpha =
+$bravo
+?? $charlie
+?: $delta
+?? $echo
+?: $foxtrot;
+PHP,
+            ],
+        ];
+    }
+}

--- a/tests/unit/Rule/HangingIndentationTest.php
+++ b/tests/unit/Rule/HangingIndentationTest.php
@@ -63,7 +63,9 @@ PHP,
 <?php
 $a = $b->c(fn() =>
         $d &&
-        $e)
+        $e,
+    $f &&
+        $g)
     ?: $start;
 
 PHP,
@@ -71,7 +73,9 @@ PHP,
 <?php
 $a = $b->c(fn() =>
 $d &&
-$e)
+$e,
+$f &&
+$g)
 ?: $start;
 PHP,
             ],
@@ -259,6 +263,73 @@ if (!$foo &&
             !$bar->quux() */)) {
     $foo = $bar;
 }
+PHP,
+            ],
+            [
+                <<<'PHP'
+<?php
+$alpha = $bravo
+    ?? $charlie
+    ?: $delta
+    ?? $echo
+    ?: $foxtrot;
+$alpha =
+    $bravo
+        ?? $charlie
+        ?: $delta
+        ?? $echo
+        ?: $foxtrot;
+
+PHP,
+                <<<'PHP'
+<?php
+$alpha = $bravo
+?? $charlie
+?: $delta
+?? $echo
+?: $foxtrot;
+$alpha =
+$bravo
+?? $charlie
+?: $delta
+?? $echo
+?: $foxtrot;
+PHP,
+            ],
+            [
+                <<<'PHP'
+<?php
+$iterator = new RecursiveDirectoryIterator($dir,
+    FilesystemIterator::KEY_AS_PATHNAME
+        | FilesystemIterator::CURRENT_AS_FILEINFO
+        | FilesystemIterator::SKIP_DOTS);
+
+PHP,
+                <<<'PHP'
+<?php
+$iterator = new RecursiveDirectoryIterator($dir,
+FilesystemIterator::KEY_AS_PATHNAME
+| FilesystemIterator::CURRENT_AS_FILEINFO
+| FilesystemIterator::SKIP_DOTS);
+PHP,
+            ],
+            [
+                <<<'PHP'
+<?php
+fn($a, $b) =>
+    $a === $b
+        ? 0
+        : $a <=>
+            $b;
+
+PHP,
+                <<<'PHP'
+<?php
+fn($a, $b) =>
+$a === $b
+? 0
+: $a <=>
+$b;
 PHP,
             ],
         ];


### PR DESCRIPTION
- Treat null coalescing operators as ternary operators for hanging indentation and alignment purposes
- Simplify checks for ternary operators
- Review `AlignTernaryOperators`
- Fix regression in `HangingIndentation` where some expressions are indented unnecessarily
- Add tests