### PR TITLE
Fix issue where ternary operators are not always identified correctly

### DIFF
--- a/src/Catalog/TokenSubType.php
+++ b/src/Catalog/TokenSubType.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Catalog;
+
+use Lkrms\Concept\ReflectiveEnumeration;
+
+/**
+ * Token sub-types
+ *
+ * @api
+ *
+ * @extends ReflectiveEnumeration<int>
+ */
+final class TokenSubType extends ReflectiveEnumeration
+{
+    public const COLON_TERNARY_OPERATOR = 0;
+
+    public const COLON_ALT_SYNTAX_DELIMITER = 1;
+
+    public const COLON_LABEL_DELIMITER = 2;
+
+    public const COLON_SWITCH_CASE_DELIMITER = 3;
+
+    public const COLON_RETURN_TYPE_DELIMITER = 4;
+
+    public const COLON_BACKED_ENUM_TYPE_DELIMITER = 5;
+
+    public const QUESTION_TERNARY_OPERATOR = 6;
+
+    public const QUESTION_NULLABLE = 7;
+}

--- a/src/Rule/PreserveLineBreaks.php
+++ b/src/Rule/PreserveLineBreaks.php
@@ -169,7 +169,7 @@ final class PreserveLineBreaks implements MultiTokenRule
         // statements and labels
         if ($token->id === T_COLON &&
                 !$token->inSwitchCase() &&
-                !$token->isLabelTerminator()) {
+                !$token->inLabel()) {
             return false;
         }
 

--- a/src/Rule/StandardWhitespace.php
+++ b/src/Rule/StandardWhitespace.php
@@ -230,7 +230,7 @@ final class StandardWhitespace implements TokenRule
         }
 
         // Add LINE after labels
-        if ($token->id === T_COLON && $token->isLabelTerminator()) {
+        if ($token->id === T_COLON && $token->inLabel()) {
             $token->WhitespaceAfter |= WhitespaceType::LINE;
 
             return;

--- a/src/Token/Concern/ContextAwareTokenTrait.php
+++ b/src/Token/Concern/ContextAwareTokenTrait.php
@@ -1,0 +1,260 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Token\Concern;
+
+use Lkrms\Exception\Exception;
+use Lkrms\PrettyPHP\Catalog\TokenSubType;
+use Lkrms\PrettyPHP\Catalog\TokenType;
+use Lkrms\PrettyPHP\Token\Token;
+use LogicException;
+
+trait ContextAwareTokenTrait
+{
+    public ?int $SubType = null;
+
+    /**
+     * Get the sub-type of a T_COLON token
+     *
+     * @return TokenSubType::COLON_*
+     */
+    final public function getColonType(): int
+    {
+        /** @var Token $this */
+        if ($this->id !== T_COLON) {
+            // @codeCoverageIgnoreStart
+            throw new LogicException('Not a T_COLON');
+            // @codeCoverageIgnoreEnd
+        }
+
+        if ($this->SubType !== null) {
+            /** @var TokenSubType::COLON_* */
+            $type = $this->SubType;
+            return $type;
+        }
+
+        if (!$this->_prevCode) {
+            // @codeCoverageIgnoreStart
+            throw new Exception('Illegal T_COLON context');
+            // @codeCoverageIgnoreEnd
+        }
+
+        if ($this->startsAlternativeSyntax()) {
+            $this->SubType = TokenSubType::COLON_ALT_SYNTAX_DELIMITER;
+        } elseif ($this->inLabel()) {
+            $this->SubType = TokenSubType::COLON_LABEL_DELIMITER;
+        } elseif ($this->inSwitchCase()) {
+            $this->SubType = TokenSubType::COLON_SWITCH_CASE_DELIMITER;
+        } elseif (
+            $this->_prevCode->id === T_STRING &&
+            $this->_prevCode->_prevCode &&
+            $this->_prevCode->_prevCode->id === T_ENUM
+        ) {
+            $this->SubType = TokenSubType::COLON_BACKED_ENUM_TYPE_DELIMITER;
+        } elseif ($this->_prevCode->id === T_CLOSE_PARENTHESIS) {
+            $prev = $this->_prevCode->_prevSibling;
+            if (
+                $prev &&
+                $prev->id === T_USE &&
+                $prev->_prevCode &&
+                $prev->_prevCode->id === T_CLOSE_PARENTHESIS
+            ) {
+                $prev = $prev->_prevCode->_prevSibling;
+            }
+            if ($prev) {
+                $prev = $prev->skipPrevSiblingsOf(
+                    T_STRING, T_READONLY, ...TokenType::AMPERSAND
+                );
+                if ($prev->id === T_FUNCTION || $prev->id === T_FN) {
+                    $this->SubType = TokenSubType::COLON_RETURN_TYPE_DELIMITER;
+                }
+            }
+        }
+
+        if ($this->SubType === null) {
+            $this->SubType = TokenSubType::COLON_TERNARY_OPERATOR;
+        }
+
+        return $this->SubType;
+    }
+
+    /**
+     * Get the sub-type of a T_QUESTION token
+     *
+     * @return TokenSubType::QUESTION_*
+     */
+    final public function getQuestionType(): int
+    {
+        /** @var Token $this */
+        if ($this->id !== T_QUESTION) {
+            // @codeCoverageIgnoreStart
+            throw new LogicException('Not a T_QUESTION');
+            // @codeCoverageIgnoreEnd
+        }
+
+        if ($this->SubType !== null) {
+            /** @var TokenSubType::QUESTION_* */
+            $type = $this->SubType;
+            return $type;
+        }
+
+        if (!$this->_prevCode) {
+            // @codeCoverageIgnoreStart
+            throw new Exception('Illegal T_QUESTION context');
+            // @codeCoverageIgnoreEnd
+        }
+
+        if ($this->_prevCode->id === T_CONST) {
+            $this->SubType = TokenSubType::QUESTION_NULLABLE;
+        } elseif ($this->_prevCode->id === T_COLON) {
+            $prevType = $this->_prevCode->getColonType();
+            if (
+                $prevType === TokenSubType::COLON_RETURN_TYPE_DELIMITER ||
+                $prevType === TokenSubType::COLON_BACKED_ENUM_TYPE_DELIMITER
+            ) {
+                $this->SubType = TokenSubType::QUESTION_NULLABLE;
+            }
+        } elseif (
+            $this->_prevCode->is([T_VAR, ...TokenType::KEYWORD_MODIFIER])
+        ) {
+            $this->SubType = TokenSubType::QUESTION_NULLABLE;
+        } elseif ($this->inParameterList()) {
+            $this->SubType = TokenSubType::QUESTION_NULLABLE;
+        }
+
+        if ($this->SubType === null) {
+            $this->SubType = TokenSubType::QUESTION_TERNARY_OPERATOR;
+        }
+
+        return $this->SubType;
+    }
+
+    /**
+     * True if the token is in a label
+     *
+     * Returns `true` if the token is a `T_STRING` or `T_COLON` comprising part
+     * of a label.
+     */
+    final public function inLabel(): bool
+    {
+        /** @var Token $this */
+
+        // Exclude named arguments
+        if ($this->Parent && $this->Parent->id === T_OPEN_PARENTHESIS) {
+            return false;
+        }
+
+        if (
+            $this->id === T_COLON &&
+            $this->_prevCode &&
+            $this->_prevCode->id === T_STRING &&
+            (!$this->_prevCode->_prevSibling ||
+                $this->_prevCode->_prevSibling->EndStatement ===
+                    $this->_prevCode->_prevSibling)
+        ) {
+            return true;
+        }
+
+        if (
+            $this->id === T_STRING &&
+            $this->_nextCode->id === T_COLON &&
+            (!$this->_prevSibling ||
+                $this->_prevSibling->EndStatement ===
+                    $this->_prevSibling)
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * True if the token encloses a parameter list
+     */
+    final public function isParameterList(): bool
+    {
+        if ($this->id !== T_OPEN_PARENTHESIS) {
+            return false;
+        }
+
+        if (!$this->_prevCode) {
+            return false;
+        }
+
+        $prev = $this->_prevCode->skipPrevSiblingsOf(
+            T_STRING,
+            T_READONLY,
+            ...TokenType::AMPERSAND,
+        );
+
+        if ($prev->id === T_FUNCTION || $prev->id === T_FN) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * True if the token is in a parameter list
+     */
+    final public function inParameterList(): bool
+    {
+        if ($this->Parent && $this->Parent->isParameterList()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * True if the token is in a T_SWITCH case list
+     */
+    final public function inSwitchCaseList(): bool
+    {
+        /** @var Token $this */
+        if (
+            $this->Parent &&
+            $this->Parent->_prevSibling &&
+            $this->Parent->_prevSibling->_prevSibling &&
+            $this->Parent->_prevSibling->_prevSibling->id === T_SWITCH
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * True if the token is in a T_CASE or T_DEFAULT statement in a T_SWITCH
+     *
+     * Returns `true` if the token is `T_CASE` or `T_DEFAULT`, part of the
+     * expression after `T_CASE`, or the subsequent `:` or `;` delimiter.
+     */
+    final public function inSwitchCase(): bool
+    {
+        /** @var Token $this */
+        if (!$this->inSwitchCaseList()) {
+            return false;
+        }
+
+        if ($this->id === T_CASE || $this->id === T_DEFAULT) {
+            return true;
+        }
+
+        $lastCaseOrDelimiter = $this->prevSiblingOf(
+            T_CASE,
+            T_DEFAULT,
+            T_COLON,
+            T_SEMICOLON,
+            T_CLOSE_TAG,
+        );
+
+        if (
+            $lastCaseOrDelimiter->id === T_CASE ||
+            $lastCaseOrDelimiter->id === T_DEFAULT
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Token/Concern/NavigableTokenTrait.php
+++ b/src/Token/Concern/NavigableTokenTrait.php
@@ -6,6 +6,7 @@ use Lkrms\PrettyPHP\Catalog\CustomToken;
 use Lkrms\PrettyPHP\Catalog\TokenType;
 use Lkrms\PrettyPHP\Filter\Contract\Filter;
 use Lkrms\PrettyPHP\Support\TokenTypeIndex;
+use Lkrms\PrettyPHP\Token\Token;
 
 trait NavigableTokenTrait
 {
@@ -20,77 +21,77 @@ trait NavigableTokenTrait
     public int $column = -1;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $_prev;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $_next;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $_prevCode;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $_nextCode;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $_prevSibling;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $_nextSibling;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $OpenedBy;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $ClosedBy;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $Parent;
 
     /**
-     * @var static[]
+     * @var Token[]
      */
     public $BracketStack = [];
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $OpenTag;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $CloseTag;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $String;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $StringClosedBy;
 
     /**
-     * @var static|null
+     * @var Token|null
      */
     public $Heredoc;
 
@@ -134,10 +135,11 @@ trait NavigableTokenTrait
     public TokenTypeIndex $TokenTypeIndex;
 
     /**
-     * @return static[]
+     * @return Token[]
      */
     public static function onlyTokenize(string $code, int $flags = 0, Filter ...$filters): array
     {
+        /** @var Token[] */
         $tokens = parent::tokenize($code, $flags);
 
         if (!$tokens) {
@@ -145,7 +147,6 @@ trait NavigableTokenTrait
         }
 
         foreach ($filters as $filter) {
-            /** @var static[] */
             $tokens = $filter->filterTokens($tokens);
         }
 
@@ -153,7 +154,7 @@ trait NavigableTokenTrait
     }
 
     /**
-     * @return static[]
+     * @return Token[]
      */
     public static function tokenize(string $code, int $flags = 0, ?TokenTypeIndex $tokenTypeIndex = null, Filter ...$filters): array
     {
@@ -172,7 +173,7 @@ trait NavigableTokenTrait
         // - assign token type index
         // - set `OpenTag`, `CloseTag`
 
-        /** @var static|null */
+        /** @var Token|null */
         $prev = null;
         foreach ($tokens as $token) {
             if ($prev) {
@@ -226,9 +227,9 @@ trait NavigableTokenTrait
         // - pair open brackets and tags with their counterparts
         // - link siblings, parents and children
 
-        /** @var static[] */
+        /** @var Token[] */
         $linked = [];
-        /** @var static|null */
+        /** @var Token|null */
         $prev = null;
         $index = 0;
 
@@ -259,7 +260,6 @@ trait NavigableTokenTrait
                 $opener = array_pop($stack);
                 if (($opener &&
                     $opener->id === T_COLON &&
-                    // $opener->BracketStack === $stack &&
                     ($token->is(TokenType::ALT_SYNTAX_END) ||
                         ($token->is(TokenType::ALT_SYNTAX_CONTINUE_WITH_EXPRESSION) &&
                             $token->nextSimpleSibling(2)->id === T_COLON) ||
@@ -367,7 +367,7 @@ trait NavigableTokenTrait
                     continue;
                 }
 
-                /** @var static */
+                /** @var Token */
                 $_prev = $token->prevSiblingOf(T_FUNCTION, T_CLASS);
                 if (!$_prev->IsNull &&
                         $_prev->nextSiblingOf(T_OPEN_BRACE)->ClosedBy === $token) {
@@ -430,7 +430,7 @@ trait NavigableTokenTrait
      */
     final public function isStructuralBrace(bool $orMatch = true): bool
     {
-        /** @var static */
+        /** @var Token */
         $current = $this->OpenedBy ?: $this;
 
         // Exclude T_CURLY_OPEN and T_DOLLAR_OPEN_CURLY_BRACES
@@ -438,7 +438,7 @@ trait NavigableTokenTrait
             return false;
         }
 
-        /** @var static|null */
+        /** @var Token|null */
         $prev = $current->_prevSibling->_prevSibling ?? null;
         if ($prev && $prev->id === T_MATCH) {
             return $orMatch;
@@ -457,7 +457,7 @@ trait NavigableTokenTrait
     /**
      * Get a new T_NULL token
      *
-     * @return static
+     * @return Token
      */
     public function null()
     {
@@ -482,9 +482,9 @@ trait NavigableTokenTrait
      *
      * Otherwise, `$token` is resolved and returned.
      *
-     * @param static|(callable(): static) $token
-     * @param (callable(static): bool)|null $condition
-     * @return static
+     * @param Token|(callable(): Token) $token
+     * @param (callable(Token): bool)|null $condition
+     * @return Token
      */
     public function or($token, ?callable $condition = null)
     {
@@ -593,7 +593,7 @@ trait NavigableTokenTrait
     /**
      * Get the previous token that is one of the listed types
      *
-     * @return static
+     * @return Token
      */
     final public function prevOf(int $type, int ...$types)
     {
@@ -610,7 +610,7 @@ trait NavigableTokenTrait
     /**
      * Get the next token that is one of the listed types
      *
-     * @return static
+     * @return Token
      */
     final public function nextOf(int $type, int ...$types)
     {
@@ -627,7 +627,7 @@ trait NavigableTokenTrait
     /**
      * Get the previous sibling that is one of the listed types
      *
-     * @return static
+     * @return Token
      */
     final public function prevSiblingOf(int $type, int ...$types)
     {
@@ -644,7 +644,7 @@ trait NavigableTokenTrait
     /**
      * Get the next sibling that is one of the listed types
      *
-     * @return static
+     * @return Token
      */
     final public function nextSiblingOf(int $type, int ...$types)
     {
@@ -663,7 +663,7 @@ trait NavigableTokenTrait
      *
      * The token returns itself if it satisfies the criteria.
      *
-     * @return static
+     * @return Token
      */
     final public function skipSiblingsOf(int $type, int ...$types)
     {
@@ -680,7 +680,7 @@ trait NavigableTokenTrait
      *
      * The token returns itself if it satisfies the criteria.
      *
-     * @return static
+     * @return Token
      */
     final public function skipPrevSiblingsOf(int $type, int ...$types)
     {
@@ -695,7 +695,7 @@ trait NavigableTokenTrait
     /**
      * Get the first reachable token
      *
-     * @return static
+     * @return Token
      */
     final public function first()
     {
@@ -709,7 +709,7 @@ trait NavigableTokenTrait
     /**
      * Get the last reachable token
      *
-     * @return static
+     * @return Token
      */
     final public function last()
     {
@@ -723,7 +723,7 @@ trait NavigableTokenTrait
     /**
      * Get the token at the beginning of the token's original line
      *
-     * @return static
+     * @return Token
      */
     final public function startOfOriginalLine()
     {
@@ -737,7 +737,7 @@ trait NavigableTokenTrait
     /**
      * Get the token at the end of the token's original line
      *
-     * @return static
+     * @return Token
      */
     final public function endOfOriginalLine()
     {
@@ -752,9 +752,9 @@ trait NavigableTokenTrait
      * Get the next sibling via token traversal, without accounting for PHP's
      * alternative syntax
      *
-     * @return static
+     * @return Token
      */
-    private function nextSimpleSibling(int $offset = 1)
+    final public function nextSimpleSibling(int $offset = 1)
     {
         $depth = 0;
         $t = $this;

--- a/tests/unit/FormatterTest.php
+++ b/tests/unit/FormatterTest.php
@@ -440,6 +440,27 @@ if ($d) {
     g(); }
 PHP,
             ],
+            'ternary with closure return type in expression 1' => [
+                <<<'PHP'
+<?php
+$filter =
+    $exclude
+        ? function ($value, $key, $iterator) use ($exclude): bool {
+            return (bool) preg_match($exclude, $key);
+        }
+        : null;
+
+PHP,
+                <<<'PHP'
+<?php
+$filter =
+$exclude
+? function ($value, $key, $iterator) use ($exclude): bool {
+return (bool) preg_match($exclude, $key);
+}
+: null;
+PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
Before:

```php
<?php
$filter =
    $exclude
        ? function ($value, $key, $iterator) use ($exclude)
        : bool {
            return (bool) preg_match($exclude, $key);
        }
    : null;
```

After:

```php
<?php
$filter =
    $exclude
        ? function ($value, $key, $iterator) use ($exclude): bool {
            return (bool) preg_match($exclude, $key);
        }
        : null;

```

- Add `ContextAwareTokenTrait` to improve separation of concerns
- Add `Token::inSwitchCaseList()` and refactor `inSwitchCase()` in `ContextAwareTokenTrait`
- Replace `Token::isLabelTerminator()` with `inLabel()` in `ContextAwareTokenTrait`
- Move `isParameterList()` and `inParameterList()` from `Token` to `ContextAwareTokenTrait`
- Add `TokenSubType` enumeration
- Add `ContextAwareTokenTrait::getColonType()` to resolve `T_COLON` tokens to `TokenSubType::COLON_*` values
- Add `ContextAwareTokenTrait::getQuestionType()` to resolve `T_QUESTION` tokens to `TokenSubType::QUESTION_*` values
- Improve PHPDoc annotations in `NavigableTokenTrait`