### PR TITLE
Update CLI usage information, improve reporting via exit status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,4 +303,4 @@ jobs:
           artifact_path: ${{ needs.build.outputs.artifact_path }}
         run: |
           php "$artifact_path" --print-config ${{ matrix.args }} | tee .prettyphp
-          php "$artifact_path" --timers || { status=$? && [[ $status -eq 2 ]] || (exit $status); }
+          php "$artifact_path" --timers || { status=$? && [[ $status -eq 4 ]] || (exit $status); }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "lkrms/util": "^0.21.9",
+        "lkrms/util": "^0.21.11",
         "sebastian/diff": "^4 || ^5"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e2cebebb63be757bbeb9cca333deb5c",
+    "content-hash": "f6b7f3ff03973148ae1566088045f8a7",
     "packages": [
         {
             "name": "lkrms/dice",
-            "version": "v4.1.7",
+            "version": "v4.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lkrms/Dice.git",
-                "reference": "1f219484fcb55a8fab4943672f73f7993480bfea"
+                "reference": "08b5151cd9cf80771d8b45808a3e19de99f1ae12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lkrms/Dice/zipball/1f219484fcb55a8fab4943672f73f7993480bfea",
-                "reference": "1f219484fcb55a8fab4943672f73f7993480bfea",
+                "url": "https://api.github.com/repos/lkrms/Dice/zipball/08b5151cd9cf80771d8b45808a3e19de99f1ae12",
+                "reference": "08b5151cd9cf80771d8b45808a3e19de99f1ae12",
                 "shasum": ""
             },
             "require": {
@@ -45,27 +45,27 @@
                 "ioc"
             ],
             "support": {
-                "source": "https://github.com/lkrms/Dice/tree/v4.1.7"
+                "source": "https://github.com/lkrms/Dice/tree/v4.1.8"
             },
-            "time": "2023-11-05T22:53:14+00:00"
+            "time": "2023-12-04T15:05:42+00:00"
         },
         {
             "name": "lkrms/util",
-            "version": "v0.21.9",
+            "version": "v0.21.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lkrms/php-util.git",
-                "reference": "b9b98e5da2e19ddb86270b1b7d84e0eeb9d9486f"
+                "reference": "46be6dcf9258fe5315a512ed4c2ab71da4534e38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lkrms/php-util/zipball/b9b98e5da2e19ddb86270b1b7d84e0eeb9d9486f",
-                "reference": "b9b98e5da2e19ddb86270b1b7d84e0eeb9d9486f",
+                "url": "https://api.github.com/repos/lkrms/php-util/zipball/46be6dcf9258fe5315a512ed4c2ab71da4534e38",
+                "reference": "46be6dcf9258fe5315a512ed4c2ab71da4534e38",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
-                "lkrms/dice": "^4.1.6",
+                "lkrms/dice": "^4.1.8",
                 "php": ">=7.4",
                 "psr/container": "^2",
                 "psr/event-dispatcher": "^1",
@@ -116,9 +116,9 @@
             "description": "A lightweight PHP toolkit for expressive backend/CLI apps",
             "support": {
                 "issues": "https://github.com/lkrms/php-util/issues",
-                "source": "https://github.com/lkrms/php-util/tree/v0.21.9"
+                "source": "https://github.com/lkrms/php-util/tree/v0.21.11"
             },
-            "time": "2023-11-30T02:19:10+00:00"
+            "time": "2023-12-08T02:45:52+00:00"
         },
         {
             "name": "psr/container",
@@ -736,16 +736,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.46",
+            "version": "1.10.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "90d3d25c5b98b8068916bbf08ce42d5cb6c54e70"
+                "reference": "84dbb33b520ea28b6cf5676a3941f4bae1c1ff39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/90d3d25c5b98b8068916bbf08ce42d5cb6c54e70",
-                "reference": "90d3d25c5b98b8068916bbf08ce42d5cb6c54e70",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/84dbb33b520ea28b6cf5676a3941f4bae1c1ff39",
+                "reference": "84dbb33b520ea28b6cf5676a3941f4bae1c1ff39",
                 "shasum": ""
             },
             "require": {
@@ -794,7 +794,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-28T14:57:26+00:00"
+            "time": "2023-12-01T15:19:17+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -1165,16 +1165,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
@@ -1248,7 +1248,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -1264,7 +1264,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -115,9 +115,8 @@ pretty-php - Format a PHP file
 
   Ignore the position of newlines in the input.
 
-  This option cannot be overridden by configuration file settings (see
-  **`CONFIGURATION`** below). Use **`--disable=preserve-newlines`** for the same effect
-  without overriding configuration files.
+  Unlike **`--disable=preserve-newlines`**, this option is not ignored when a
+  configuration file is applied.
 
 - **`-S`**, **`--no-simplify-strings`**
 
@@ -152,10 +151,6 @@ pretty-php - Format a PHP file
 
   Enforce strict PSR-12 / PER Coding Style compliance.
 
-  Use this option to apply formatting rules and internal options required
-  for **`pretty-php`** output to satisfy the formatting-related requirements of
-  PHP-FIG coding style standards.
-
 - **`-p`**, **`--preset`** (`drupal`|`laravel`|`symfony`|`wordpress`)
 
   Apply a formatting preset.
@@ -177,9 +172,8 @@ pretty-php - Format a PHP file
 
   Ignore configuration files.
 
-  Use this option to skip detection of configuration files that would
-  otherwise take precedence over formatting options given on the command
-  line.
+  Use this option to ignore any configuration files that would usually apply
+  to the input.
 
   See **`CONFIGURATION`** below.
 
@@ -217,8 +211,9 @@ pretty-php - Format a PHP file
 
   Create debug output in *<u>directory</u>*.
 
-  Combine with **`-v/--verbose`** to render output to a subdirectory of *<u>directory</u>*
-  after processing each pass of each rule.
+  If combined with **`-v/--verbose`**, partially formatted code is written to a
+  series of files in `<directory>/progress-log` that represent changes applied
+  by enabled rules.
 
 - **`--timers`**
 
@@ -246,32 +241,31 @@ pretty-php - Format a PHP file
 **`pretty-php`** looks for a JSON configuration file named `.prettyphp` or
 `prettyphp.json` in the same directory as each input file, then in each of its
 parent directories. It stops looking when it finds a configuration file, a
-`.git` directory, a `.hg` directory, or the root of the filesystem, whichever
-comes first.
+`.git`, `.hg` or `.svn` directory, or the root of the filesystem, whichever comes
+first.
 
-If an input file has an applicable configuration file, command-line
-formatting options other than **`-N/--ignore-newlines`** are replaced with
-settings from the configuration file.
+If a configuration file is found, **`pretty-php`** formats the input using
+formatting options read from the configuration file, and command-line
+formatting options other than **`-N/--ignore-newlines`** are ignored.
 
 The **`--print-config`** option can be used to generate a configuration file, for
 example:
 
-    $ pretty-php -P -S -M --print-config src tests bootstrap.php
-    {
-        "src": [
-            "src",
-            "tests",
-            "bootstrap.php"
-        ],
-        "includeIfPhp": true,
-        "noSimplifyStrings": true,
-        "noSortImports": true
-    }
+```console
+$ pretty-php --sort-imports-by=name --psr12 src tests --print-config
+{
+    "src": [
+        "src",
+        "tests"
+    ],
+    "sortImportsBy": "name",
+    "psr12": true
+}
+```
 
-The optional `src` array specifies files and directories to format. If
-**`pretty-php`** is started with no path arguments in a directory where `src` is
-configured, or the directory is passed to **`pretty-php`** for formatting, paths
-in `src` are formatted. It is ignored otherwise.
+The optional `src` array specifies files and directories to format when
+**`pretty-php`** is started in the same directory or when the directory is passed
+to **`pretty-php`** for formatting.
 
 If a directory contains more than one configuration file, **`pretty-php`** reports
 an error and exits without formatting anything.
@@ -279,9 +273,7 @@ an error and exits without formatting anything.
 ## EXIT STATUS
 
 **`pretty-php`** returns 0 when formatting succeeds, 1 when invalid arguments are
-given, and 2 when one or more input files cannot be parsed. Other non-zero
-values are returned for other failures.
-
-When **`--diff`** or **`--check`** are given, **`pretty-php`** returns 0 when the input is
-already formatted and 1 when formatting is required. The meaning of other
-return values is unchanged.
+given, 2 when invalid configuration files are found, and 4 when one or more
+input files cannot be parsed. When **`--diff`** or **`--check`** are given, **`pretty-php`**
+returns 0 when the input is already formatted and 8 when formatting is
+required.

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,29 +2,75 @@
 
 set -euo pipefail
 
-die() {
-    printf '%s: %s\n' "$0" "$1" >&2
-    exit 1
+# die [<message>]
+function die() {
+    local s=$?
+    printf '%s: %s\n' "${0##*/}" "${1-command failed}" >&2
+    ((!s)) && exit 1 || exit "$s"
+}
+
+# usage [<error-message>]
+function usage() {
+    if (($#)); then
+        cat >&2 && false || die "$@"
+    else
+        cat
+    fi <<EOF
+usage: ${0##*/}                        generate everything
+       ${0##*/} --assets               generate code and documentation
+       ${0##*/} --fixtures             generate test fixtures
+       ${0##*/} [--fixtures] phpXY...  use PHP versions to generate fixtures${1:+
+}
+EOF
+    exit
 }
 
 [[ ${BASH_SOURCE[0]} -ef scripts/generate.sh ]] ||
     die "must run from root of package folder"
 
-(($#)) || set -- php83 php82 php81 php80 php74
-
-for PHP in "$@"; do
-    type -P "$PHP" >/dev/null ||
-        die "command not found: $PHP"
+ASSETS=1
+FIXTURES=1
+if [[ ${1-} == -* ]]; then
+    ASSETS=0
+    FIXTURES=0
+fi
+while [[ ${1-} == -* ]]; do
+    case "$1" in
+    --assets)
+        ASSETS=1
+        ;;
+    --fixtures)
+        FIXTURES=1
+        ;;
+    -h | --help)
+        usage
+        ;;
+    *)
+        usage "invalid argument: $1"
+        ;;
+    esac
+    shift
 done
 
-rm -rf tests/fixtures/Formatter/versions.json tests/fixtures/Formatter/out/*
+if ((FIXTURES)); then
+    (($#)) || set -- php83 php82 php81 php80 php74
 
-for PHP in "$@"; do
-    "$PHP" scripts/generate-test-output.php
-done
+    for PHP in "$@"; do
+        type -P "$PHP" >/dev/null ||
+            die "command not found: $PHP"
+    done
 
-FILE=docs/Usage.md
-printf '==> generating %s\n' "$FILE"
-bin/pretty-php _md >"$FILE"
+    rm -rf tests/fixtures/Formatter/versions.json tests/fixtures/Formatter/out/*
 
-vendor/bin/lk-util generate builder --no-meta --force 'Lkrms\PrettyPHP\Formatter'
+    for PHP in "$@"; do
+        "$PHP" scripts/generate-test-output.php
+    done
+fi
+
+if ((ASSETS)); then
+    FILE=docs/Usage.md
+    printf '==> generating %s\n' "$FILE"
+    bin/pretty-php _md >"$FILE"
+
+    vendor/bin/lk-util generate builder --no-meta --force 'Lkrms\PrettyPHP\Formatter'
+fi

--- a/src/Exception/FilterException.php
+++ b/src/Exception/FilterException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Exception;
+
+use Lkrms\Exception\Exception;
+
+/**
+ * Thrown when filter processing fails
+ */
+class FilterException extends Exception {}

--- a/src/Exception/IncompatibleRulesException.php
+++ b/src/Exception/IncompatibleRulesException.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Exception;
+
+use Lkrms\Exception\Exception;
+use Lkrms\PrettyPHP\Rule\Contract\Rule;
+
+/**
+ * Thrown when incompatible rules are enabled
+ */
+class IncompatibleRulesException extends Exception
+{
+    /**
+     * @var array<class-string<Rule>>
+     */
+    protected array $Rules;
+
+    /**
+     * @param class-string<Rule> $rule1
+     * @param class-string<Rule> $rule2
+     * @param class-string<Rule> ...$rules
+     */
+    public function __construct(string $rule1, string $rule2, string ...$rules)
+    {
+        array_unshift($rules, $rule1, $rule2);
+        $this->Rules = $rules;
+
+        parent::__construct(sprintf(
+            'Enabled rules are not compatible: %s',
+            implode(', ', $this->Rules)
+        ));
+    }
+}

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Exception;
+
+use Lkrms\Exception\Exception;
+use Throwable;
+
+/**
+ * Thrown when an invalid configuration file is found
+ */
+class InvalidConfigurationException extends Exception
+{
+    public function __construct(string $message = '', ?Throwable $previous = null)
+    {
+        parent::__construct($message, $previous, 2);
+    }
+}

--- a/src/Exception/RuleException.php
+++ b/src/Exception/RuleException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Exception;
+
+use Lkrms\Exception\Exception;
+
+/**
+ * Thrown when rule processing fails
+ */
+class RuleException extends Exception {}

--- a/src/Filter/StandardiseStrings.php
+++ b/src/Filter/StandardiseStrings.php
@@ -3,10 +3,10 @@
 namespace Lkrms\PrettyPHP\Filter;
 
 use Lkrms\PrettyPHP\Concern\ExtensionTrait;
+use Lkrms\PrettyPHP\Exception\FilterException;
 use Lkrms\PrettyPHP\Filter\Contract\Filter;
 use Lkrms\PrettyPHP\Token\Token;
 use Lkrms\Utility\Pcre;
-use RuntimeException;
 
 /**
  * Evaluate strings for comparison
@@ -80,7 +80,7 @@ final class StandardiseStrings implements Filter
                 $end = Pcre::replace('/[^a-zA-Z0-9_]+/', '', $start);
                 eval("\$string = {$start}\n{$token->text}\n{$end};");
             } else {
-                throw new RuntimeException('Error parsing string');
+                throw new FilterException('Error parsing string');
             }
             $token->setText($string);
         }

--- a/src/FormatterBuilder.php
+++ b/src/FormatterBuilder.php
@@ -4,6 +4,8 @@ namespace Lkrms\PrettyPHP;
 
 use Lkrms\Concept\Builder;
 use Lkrms\PrettyPHP\Catalog\FormatterFlag;
+use Lkrms\PrettyPHP\Catalog\HeredocIndent;
+use Lkrms\PrettyPHP\Catalog\ImportSortOrder;
 use Lkrms\PrettyPHP\Filter\Contract\Filter;
 use Lkrms\PrettyPHP\Rule\Contract\Rule;
 use Lkrms\PrettyPHP\Support\TokenTypeIndex;
@@ -12,12 +14,18 @@ use Lkrms\PrettyPHP\Support\TokenTypeIndex;
  * Creates Formatter objects via a fluent interface
  *
  * @method $this insertSpaces(bool $value = true) Use spaces for indentation? (default: true)
- * @method $this tabSize(int $value) The size of a tab, in spaces
+ * @method $this tabSize((2|4|8) $value) The size of a tab, in spaces
  * @method $this disableRules(array<class-string<Rule>> $value) Non-mandatory rules to disable
  * @method $this enableRules(array<class-string<Rule>> $value) Additional rules to enable
  * @method $this disableFilters(array<class-string<Filter>> $value) Optional filters to disable
  * @method $this flags(int-mask-of<FormatterFlag::*> $value) Debugging flags
  * @method $this tokenTypeIndex(TokenTypeIndex|null $value) Provide a customised token type index
+ * @method $this preferredEol(string $value) End-of-line sequence used when line endings are not preserved or when there are no line breaks in the input
+ * @method $this preserveEol(bool $value = true) True if line endings are preserved (default: true)
+ * @method $this spacesBesideCode(int $value) Spaces between code and comments on the same line
+ * @method $this heredocIndent(HeredocIndent::* $value) Indentation applied to heredocs and nowdocs
+ * @method $this importSortOrder(ImportSortOrder::* $value) Set Formatter::$ImportSortOrder
+ * @method $this oneTrueBraceStyle(bool $value = true) True if braces are formatted using the One True Brace Style (default: false)
  *
  * @uses Formatter
  *

--- a/src/Rule/NormaliseStrings.php
+++ b/src/Rule/NormaliseStrings.php
@@ -3,10 +3,10 @@
 namespace Lkrms\PrettyPHP\Rule;
 
 use Lkrms\PrettyPHP\Catalog\CustomToken;
+use Lkrms\PrettyPHP\Exception\RuleException;
 use Lkrms\PrettyPHP\Rule\Concern\MultiTokenRuleTrait;
 use Lkrms\PrettyPHP\Rule\Contract\MultiTokenRule;
 use Lkrms\Utility\Pcre;
-use RuntimeException;
 
 /**
  * Normalise escape sequences in strings, and replace single- and double-quoted
@@ -107,7 +107,7 @@ final class NormaliseStrings implements MultiTokenRule
                 }
                 eval("\$string = {$start}\n{$text}\n{$end};");
             } else {
-                throw new RuntimeException(
+                throw new RuleException(
                     sprintf('Not a string delimiter: %s', CustomToken::toName($token->String->id))
                 );
             }

--- a/tests/fixtures/Command/FormatPhp/wordpress/class-wp-plugin-install-list-table.in
+++ b/tests/fixtures/Command/FormatPhp/wordpress/class-wp-plugin-install-list-table.in
@@ -1,0 +1,831 @@
+<?php
+/**
+ * List Table API: WP_Plugin_Install_List_Table class
+ *
+ * @package WordPress
+ * @subpackage Administration
+ * @since 3.1.0
+ */
+
+/**
+ * Core class used to implement displaying plugins to install in a list table.
+ *
+ * @since 3.1.0
+ *
+ * @see WP_List_Table
+ */
+class WP_Plugin_Install_List_Table extends WP_List_Table {
+
+	public $order   = 'ASC';
+	public $orderby = null;
+	public $groups  = array();
+
+	private $error;
+
+	/**
+	 * @return bool
+	 */
+	public function ajax_user_can() {
+		return current_user_can( 'install_plugins' );
+	}
+
+	/**
+	 * Returns the list of known plugins.
+	 *
+	 * Uses the transient data from the updates API to determine the known
+	 * installed plugins.
+	 *
+	 * @since 4.9.0
+	 * @access protected
+	 *
+	 * @return array
+	 */
+	protected function get_installed_plugins() {
+		$plugins = array();
+
+		$plugin_info = get_site_transient( 'update_plugins' );
+		if ( isset( $plugin_info->no_update ) ) {
+			foreach ( $plugin_info->no_update as $plugin ) {
+				if ( isset( $plugin->slug ) ) {
+					$plugin->upgrade          = false;
+					$plugins[ $plugin->slug ] = $plugin;
+				}
+			}
+		}
+
+		if ( isset( $plugin_info->response ) ) {
+			foreach ( $plugin_info->response as $plugin ) {
+				if ( isset( $plugin->slug ) ) {
+					$plugin->upgrade          = true;
+					$plugins[ $plugin->slug ] = $plugin;
+				}
+			}
+		}
+
+		return $plugins;
+	}
+
+	/**
+	 * Returns a list of slugs of installed plugins, if known.
+	 *
+	 * Uses the transient data from the updates API to determine the slugs of
+	 * known installed plugins. This might be better elsewhere, perhaps even
+	 * within get_plugins().
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	protected function get_installed_plugin_slugs() {
+		return array_keys( $this->get_installed_plugins() );
+	}
+
+	/**
+	 * @global array  $tabs
+	 * @global string $tab
+	 * @global int    $paged
+	 * @global string $type
+	 * @global string $term
+	 */
+	public function prepare_items() {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		global $tabs, $tab, $paged, $type, $term;
+
+		wp_reset_vars( array( 'tab' ) );
+
+		$paged = $this->get_pagenum();
+
+		$per_page = 36;
+
+		// These are the tabs which are shown on the page.
+		$tabs = array();
+
+		if ( 'search' === $tab ) {
+			$tabs['search'] = __( 'Search Results' );
+		}
+
+		if ( 'beta' === $tab || str_contains( get_bloginfo( 'version' ), '-' ) ) {
+			$tabs['beta'] = _x( 'Beta Testing', 'Plugin Installer' );
+		}
+
+		$tabs['featured']    = _x( 'Featured', 'Plugin Installer' );
+		$tabs['popular']     = _x( 'Popular', 'Plugin Installer' );
+		$tabs['recommended'] = _x( 'Recommended', 'Plugin Installer' );
+		$tabs['favorites']   = _x( 'Favorites', 'Plugin Installer' );
+
+		if ( current_user_can( 'upload_plugins' ) ) {
+			/*
+			 * No longer a real tab. Here for filter compatibility.
+			 * Gets skipped in get_views().
+			 */
+			$tabs['upload'] = __( 'Upload Plugin' );
+		}
+
+		$nonmenu_tabs = array( 'plugin-information' ); // Valid actions to perform which do not have a Menu item.
+
+		/**
+		 * Filters the tabs shown on the Add Plugins screen.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param string[] $tabs The tabs shown on the Add Plugins screen. Defaults include
+		 *                       'featured', 'popular', 'recommended', 'favorites', and 'upload'.
+		 */
+		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
+
+		/**
+		 * Filters tabs not associated with a menu item on the Add Plugins screen.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param string[] $nonmenu_tabs The tabs that don't have a menu item on the Add Plugins screen.
+		 */
+		$nonmenu_tabs = apply_filters( 'install_plugins_nonmenu_tabs', $nonmenu_tabs );
+
+		// If a non-valid menu tab has been selected, And it's not a non-menu action.
+		if ( empty( $tab ) || ( ! isset( $tabs[ $tab ] ) && ! in_array( $tab, (array) $nonmenu_tabs, true ) ) ) {
+			$tab = key( $tabs );
+		}
+
+		$installed_plugins = $this->get_installed_plugins();
+
+		$args = array(
+			'page'     => $paged,
+			'per_page' => $per_page,
+			// Send the locale to the API so it can provide context-sensitive results.
+			'locale'   => get_user_locale(),
+		);
+
+		switch ( $tab ) {
+			case 'search':
+				$type = isset( $_REQUEST['type'] ) ? wp_unslash( $_REQUEST['type'] ) : 'term';
+				$term = isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : '';
+
+				switch ( $type ) {
+					case 'tag':
+						$args['tag'] = sanitize_title_with_dashes( $term );
+						break;
+					case 'term':
+						$args['search'] = $term;
+						break;
+					case 'author':
+						$args['author'] = $term;
+						break;
+				}
+
+				break;
+
+			case 'featured':
+			case 'popular':
+			case 'new':
+			case 'beta':
+				$args['browse'] = $tab;
+				break;
+			case 'recommended':
+				$args['browse'] = $tab;
+				// Include the list of installed plugins so we can get relevant results.
+				$args['installed_plugins'] = array_keys( $installed_plugins );
+				break;
+
+			case 'favorites':
+				$action = 'save_wporg_username_' . get_current_user_id();
+				if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), $action ) ) {
+					$user = isset( $_GET['user'] ) ? wp_unslash( $_GET['user'] ) : get_user_option( 'wporg_favorites' );
+
+					// If the save url parameter is passed with a falsey value, don't save the favorite user.
+					if ( ! isset( $_GET['save'] ) || $_GET['save'] ) {
+						update_user_meta( get_current_user_id(), 'wporg_favorites', $user );
+					}
+				} else {
+					$user = get_user_option( 'wporg_favorites' );
+				}
+				if ( $user ) {
+					$args['user'] = $user;
+				} else {
+					$args = false;
+				}
+
+				add_action( 'install_plugins_favorites', 'install_plugins_favorites_form', 9, 0 );
+				break;
+
+			default:
+				$args = false;
+				break;
+		}
+
+		/**
+		 * Filters API request arguments for each Add Plugins screen tab.
+		 *
+		 * The dynamic portion of the hook name, `$tab`, refers to the plugin install tabs.
+		 *
+		 * Possible hook names include:
+		 *
+		 *  - `install_plugins_table_api_args_favorites`
+		 *  - `install_plugins_table_api_args_featured`
+		 *  - `install_plugins_table_api_args_popular`
+		 *  - `install_plugins_table_api_args_recommended`
+		 *  - `install_plugins_table_api_args_upload`
+		 *  - `install_plugins_table_api_args_search`
+		 *  - `install_plugins_table_api_args_beta`
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param array|false $args Plugin install API arguments.
+		 */
+		$args = apply_filters( "install_plugins_table_api_args_{$tab}", $args );
+
+		if ( ! $args ) {
+			return;
+		}
+
+		$api = plugins_api( 'query_plugins', $args );
+
+		if ( is_wp_error( $api ) ) {
+			$this->error = $api;
+			return;
+		}
+
+		$this->items = $api->plugins;
+
+		if ( $this->orderby ) {
+			uasort( $this->items, array( $this, 'order_callback' ) );
+		}
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $api->info['results'],
+				'per_page'    => $args['per_page'],
+			)
+		);
+
+		if ( isset( $api->info['groups'] ) ) {
+			$this->groups = $api->info['groups'];
+		}
+
+		if ( $installed_plugins ) {
+			$js_plugins = array_fill_keys(
+				array( 'all', 'search', 'active', 'inactive', 'recently_activated', 'mustuse', 'dropins' ),
+				array()
+			);
+
+			$js_plugins['all'] = array_values( wp_list_pluck( $installed_plugins, 'plugin' ) );
+			$upgrade_plugins   = wp_filter_object_list( $installed_plugins, array( 'upgrade' => true ), 'and', 'plugin' );
+
+			if ( $upgrade_plugins ) {
+				$js_plugins['upgrade'] = array_values( $upgrade_plugins );
+			}
+
+			wp_localize_script(
+				'updates',
+				'_wpUpdatesItemCounts',
+				array(
+					'plugins' => $js_plugins,
+					'totals'  => wp_get_update_data(),
+				)
+			);
+		}
+	}
+
+	/**
+	 */
+	public function no_items() {
+		if ( isset( $this->error ) ) {
+			$error_message  = '<p>' . $this->error->get_error_message() . '</p>';
+			$error_message .= '<p class="hide-if-no-js"><button class="button try-again">' . __( 'Try Again' ) . '</button></p>';
+			wp_admin_notice(
+				$error_message,
+				array(
+					'additional_classes' => array( 'inline', 'error' ),
+					'paragraph_wrap'     => false,
+				)
+			);
+			?>
+		<?php } else { ?>
+			<div class="no-plugin-results"><?php _e( 'No plugins found. Try a different search.' ); ?></div>
+			<?php
+		}
+	}
+
+	/**
+	 * @global array $tabs
+	 * @global string $tab
+	 *
+	 * @return array
+	 */
+	protected function get_views() {
+		global $tabs, $tab;
+
+		$display_tabs = array();
+		foreach ( (array) $tabs as $action => $text ) {
+			$display_tabs[ 'plugin-install-' . $action ] = array(
+				'url'     => self_admin_url( 'plugin-install.php?tab=' . $action ),
+				'label'   => $text,
+				'current' => $action === $tab,
+			);
+		}
+		// No longer a real tab.
+		unset( $display_tabs['plugin-install-upload'] );
+
+		return $this->get_views_links( $display_tabs );
+	}
+
+	/**
+	 * Overrides parent views so we can use the filter bar display.
+	 */
+	public function views() {
+		$views = $this->get_views();
+
+		/** This filter is documented in wp-admin/includes/class-wp-list-table.php */
+		$views = apply_filters( "views_{$this->screen->id}", $views );
+
+		$this->screen->render_screen_reader_content( 'heading_views' );
+		?>
+<div class="wp-filter">
+	<ul class="filter-links">
+		<?php
+		if ( ! empty( $views ) ) {
+			foreach ( $views as $class => $view ) {
+				$views[ $class ] = "\t<li class='$class'>$view";
+			}
+			echo implode( " </li>\n", $views ) . "</li>\n";
+		}
+		?>
+	</ul>
+
+		<?php install_search_form(); ?>
+</div>
+		<?php
+	}
+
+	/**
+	 * Displays the plugin install table.
+	 *
+	 * Overrides the parent display() method to provide a different container.
+	 *
+	 * @since 4.0.0
+	 */
+	public function display() {
+		$singular = $this->_args['singular'];
+
+		$data_attr = '';
+
+		if ( $singular ) {
+			$data_attr = " data-wp-lists='list:$singular'";
+		}
+
+		$this->display_tablenav( 'top' );
+
+		?>
+<div class="wp-list-table <?php echo implode( ' ', $this->get_table_classes() ); ?>">
+		<?php
+		$this->screen->render_screen_reader_content( 'heading_list' );
+		?>
+	<div id="the-list"<?php echo $data_attr; ?>>
+		<?php $this->display_rows_or_placeholder(); ?>
+	</div>
+</div>
+		<?php
+		$this->display_tablenav( 'bottom' );
+	}
+
+	/**
+	 * @global string $tab
+	 *
+	 * @param string $which
+	 */
+	protected function display_tablenav( $which ) {
+		if ( 'featured' === $GLOBALS['tab'] ) {
+			return;
+		}
+
+		if ( 'top' === $which ) {
+			wp_referer_field();
+			?>
+			<div class="tablenav top">
+				<div class="alignleft actions">
+					<?php
+					/**
+					 * Fires before the Plugin Install table header pagination is displayed.
+					 *
+					 * @since 2.7.0
+					 */
+					do_action( 'install_plugins_table_header' );
+					?>
+				</div>
+				<?php $this->pagination( $which ); ?>
+				<br class="clear" />
+			</div>
+		<?php } else { ?>
+			<div class="tablenav bottom">
+				<?php $this->pagination( $which ); ?>
+				<br class="clear" />
+			</div>
+			<?php
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function get_table_classes() {
+		return array( 'widefat', $this->_args['plural'] );
+	}
+
+	/**
+	 * @return string[] Array of column titles keyed by their column name.
+	 */
+	public function get_columns() {
+		return array();
+	}
+
+	/**
+	 * @param object $plugin_a
+	 * @param object $plugin_b
+	 * @return int
+	 */
+	private function order_callback( $plugin_a, $plugin_b ) {
+		$orderby = $this->orderby;
+		if ( ! isset( $plugin_a->$orderby, $plugin_b->$orderby ) ) {
+			return 0;
+		}
+
+		$a = $plugin_a->$orderby;
+		$b = $plugin_b->$orderby;
+
+		if ( $a === $b ) {
+			return 0;
+		}
+
+		if ( 'DESC' === $this->order ) {
+			return ( $a < $b ) ? 1 : -1;
+		} else {
+			return ( $a < $b ) ? -1 : 1;
+		}
+	}
+
+	public function display_rows() {
+		$plugins_allowedtags = array(
+			'a'       => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'abbr'    => array( 'title' => array() ),
+			'acronym' => array( 'title' => array() ),
+			'code'    => array(),
+			'pre'     => array(),
+			'em'      => array(),
+			'strong'  => array(),
+			'ul'      => array(),
+			'ol'      => array(),
+			'li'      => array(),
+			'p'       => array(),
+			'br'      => array(),
+		);
+
+		$plugins_group_titles = array(
+			'Performance' => _x( 'Performance', 'Plugin installer group title' ),
+			'Social'      => _x( 'Social', 'Plugin installer group title' ),
+			'Tools'       => _x( 'Tools', 'Plugin installer group title' ),
+		);
+
+		$group = null;
+
+		foreach ( (array) $this->items as $plugin ) {
+			if ( is_object( $plugin ) ) {
+				$plugin = (array) $plugin;
+			}
+
+			// Display the group heading if there is one.
+			if ( isset( $plugin['group'] ) && $plugin['group'] !== $group ) {
+				if ( isset( $this->groups[ $plugin['group'] ] ) ) {
+					$group_name = $this->groups[ $plugin['group'] ];
+					if ( isset( $plugins_group_titles[ $group_name ] ) ) {
+						$group_name = $plugins_group_titles[ $group_name ];
+					}
+				} else {
+					$group_name = $plugin['group'];
+				}
+
+				// Starting a new group, close off the divs of the last one.
+				if ( ! empty( $group ) ) {
+					echo '</div></div>';
+				}
+
+				echo '<div class="plugin-group"><h3>' . esc_html( $group_name ) . '</h3>';
+				// Needs an extra wrapping div for nth-child selectors to work.
+				echo '<div class="plugin-items">';
+
+				$group = $plugin['group'];
+			}
+
+			$title = wp_kses( $plugin['name'], $plugins_allowedtags );
+
+			// Remove any HTML from the description.
+			$description = strip_tags( $plugin['short_description'] );
+
+			/**
+			 * Filters the plugin card description on the Add Plugins screen.
+			 *
+			 * @since 6.0.0
+			 *
+			 * @param string $description Plugin card description.
+			 * @param array  $plugin      An array of plugin data. See {@see plugins_api()}
+			 *                            for the list of possible values.
+			 */
+			$description = apply_filters( 'plugin_install_description', $description, $plugin );
+
+			$version = wp_kses( $plugin['version'], $plugins_allowedtags );
+
+			$name = strip_tags( $title . ' ' . $version );
+
+			$author = wp_kses( $plugin['author'], $plugins_allowedtags );
+			if ( ! empty( $author ) ) {
+				/* translators: %s: Plugin author. */
+				$author = ' <cite>' . sprintf( __( 'By %s' ), $author ) . '</cite>';
+			}
+
+			$requires_php = isset( $plugin['requires_php'] ) ? $plugin['requires_php'] : null;
+			$requires_wp  = isset( $plugin['requires'] ) ? $plugin['requires'] : null;
+
+			$compatible_php = is_php_version_compatible( $requires_php );
+			$compatible_wp  = is_wp_version_compatible( $requires_wp );
+			$tested_wp      = ( empty( $plugin['tested'] ) || version_compare( get_bloginfo( 'version' ), $plugin['tested'], '<=' ) );
+
+			$action_links = array();
+
+			if ( current_user_can( 'install_plugins' ) || current_user_can( 'update_plugins' ) ) {
+				$status = install_plugin_install_status( $plugin );
+
+				switch ( $status['status'] ) {
+					case 'install':
+						if ( $status['url'] ) {
+							if ( $compatible_php && $compatible_wp ) {
+								$action_links[] = sprintf(
+									'<a class="install-now button" data-slug="%s" href="%s" aria-label="%s" data-name="%s">%s</a>',
+									esc_attr( $plugin['slug'] ),
+									esc_url( $status['url'] ),
+									/* translators: %s: Plugin name and version. */
+									esc_attr( sprintf( _x( 'Install %s now', 'plugin' ), $name ) ),
+									esc_attr( $name ),
+									__( 'Install Now' )
+								);
+							} else {
+								$action_links[] = sprintf(
+									'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+									_x( 'Cannot Install', 'plugin' )
+								);
+							}
+						}
+						break;
+
+					case 'update_available':
+						if ( $status['url'] ) {
+							if ( $compatible_php && $compatible_wp ) {
+								$action_links[] = sprintf(
+									'<a class="update-now button aria-button-if-js" data-plugin="%s" data-slug="%s" href="%s" aria-label="%s" data-name="%s">%s</a>',
+									esc_attr( $status['file'] ),
+									esc_attr( $plugin['slug'] ),
+									esc_url( $status['url'] ),
+									/* translators: %s: Plugin name and version. */
+									esc_attr( sprintf( _x( 'Update %s now', 'plugin' ), $name ) ),
+									esc_attr( $name ),
+									__( 'Update Now' )
+								);
+							} else {
+								$action_links[] = sprintf(
+									'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+									_x( 'Cannot Update', 'plugin' )
+								);
+							}
+						}
+						break;
+
+					case 'latest_installed':
+					case 'newer_installed':
+						if ( is_plugin_active( $status['file'] ) ) {
+							$action_links[] = sprintf(
+								'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+								_x( 'Active', 'plugin' )
+							);
+						} elseif ( current_user_can( 'activate_plugin', $status['file'] ) ) {
+							if ( $compatible_php && $compatible_wp ) {
+								$button_text = __( 'Activate' );
+								/* translators: %s: Plugin name. */
+								$button_label = _x( 'Activate %s', 'plugin' );
+								$activate_url = add_query_arg(
+									array(
+										'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $status['file'] ),
+										'action'   => 'activate',
+										'plugin'   => $status['file'],
+									),
+									network_admin_url( 'plugins.php' )
+								);
+
+								if ( is_network_admin() ) {
+									$button_text = __( 'Network Activate' );
+									/* translators: %s: Plugin name. */
+									$button_label = _x( 'Network Activate %s', 'plugin' );
+									$activate_url = add_query_arg( array( 'networkwide' => 1 ), $activate_url );
+								}
+
+								$action_links[] = sprintf(
+									'<a href="%1$s" class="button activate-now" aria-label="%2$s">%3$s</a>',
+									esc_url( $activate_url ),
+									esc_attr( sprintf( $button_label, $plugin['name'] ) ),
+									$button_text
+								);
+							} else {
+								$action_links[] = sprintf(
+									'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+									_x( 'Cannot Activate', 'plugin' )
+								);
+							}
+						} else {
+							$action_links[] = sprintf(
+								'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+								_x( 'Installed', 'plugin' )
+							);
+						}
+						break;
+				}
+			}
+
+			$details_link = self_admin_url(
+				'plugin-install.php?tab=plugin-information&amp;plugin=' . $plugin['slug'] .
+				'&amp;TB_iframe=true&amp;width=600&amp;height=550'
+			);
+
+			$action_links[] = sprintf(
+				'<a href="%s" class="thickbox open-plugin-details-modal" aria-label="%s" data-title="%s">%s</a>',
+				esc_url( $details_link ),
+				/* translators: %s: Plugin name and version. */
+				esc_attr( sprintf( __( 'More information about %s' ), $name ) ),
+				esc_attr( $name ),
+				__( 'More Details' )
+			);
+
+			if ( ! empty( $plugin['icons']['svg'] ) ) {
+				$plugin_icon_url = $plugin['icons']['svg'];
+			} elseif ( ! empty( $plugin['icons']['2x'] ) ) {
+				$plugin_icon_url = $plugin['icons']['2x'];
+			} elseif ( ! empty( $plugin['icons']['1x'] ) ) {
+				$plugin_icon_url = $plugin['icons']['1x'];
+			} else {
+				$plugin_icon_url = $plugin['icons']['default'];
+			}
+
+			/**
+			 * Filters the install action links for a plugin.
+			 *
+			 * @since 2.7.0
+			 *
+			 * @param string[] $action_links An array of plugin action links.
+			 *                               Defaults are links to Details and Install Now.
+			 * @param array    $plugin       An array of plugin data. See {@see plugins_api()}
+			 *                               for the list of possible values.
+			 */
+			$action_links = apply_filters( 'plugin_install_action_links', $action_links, $plugin );
+
+			$last_updated_timestamp = strtotime( $plugin['last_updated'] );
+			?>
+		<div class="plugin-card plugin-card-<?php echo sanitize_html_class( $plugin['slug'] ); ?>">
+			<?php
+			if ( ! $compatible_php || ! $compatible_wp ) {
+				$incompatible_notice_message = '';
+				if ( ! $compatible_php && ! $compatible_wp ) {
+					$incompatible_notice_message .= __( 'This plugin does not work with your versions of WordPress and PHP.' );
+					if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+							' ' . __( '<a href="%1$s">Please update WordPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
+						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
+					} elseif ( current_user_can( 'update_core' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: %s: URL to WordPress Updates screen. */
+							' ' . __( '<a href="%s">Please update WordPress</a>.' ),
+							self_admin_url( 'update-core.php' )
+						);
+					} elseif ( current_user_can( 'update_php' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);
+						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
+					}
+				} elseif ( ! $compatible_wp ) {
+					$incompatible_notice_message .= __( 'This plugin does not work with your version of WordPress.' );
+					if ( current_user_can( 'update_core' ) ) {
+						$incompatible_notice_message .= printf(
+							/* translators: %s: URL to WordPress Updates screen. */
+							' ' . __( '<a href="%s">Please update WordPress</a>.' ),
+							self_admin_url( 'update-core.php' )
+						);
+					}
+				} elseif ( ! $compatible_php ) {
+					$incompatible_notice_message .= __( 'This plugin does not work with your version of PHP.' );
+					if ( current_user_can( 'update_php' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);
+						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
+					}
+				}
+
+				wp_admin_notice(
+					$incompatible_notice_message,
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt', 'inline' ),
+					)
+				);
+			}
+			?>
+			<div class="plugin-card-top">
+				<div class="name column-name">
+					<h3>
+						<a href="<?php echo esc_url( $details_link ); ?>" class="thickbox open-plugin-details-modal">
+						<?php echo $title; ?>
+						<img src="<?php echo esc_url( $plugin_icon_url ); ?>" class="plugin-icon" alt="" />
+						</a>
+					</h3>
+				</div>
+				<div class="action-links">
+					<?php
+					if ( $action_links ) {
+						echo '<ul class="plugin-action-buttons"><li>' . implode( '</li><li>', $action_links ) . '</li></ul>';
+					}
+					?>
+				</div>
+				<div class="desc column-description">
+					<p><?php echo $description; ?></p>
+					<p class="authors"><?php echo $author; ?></p>
+				</div>
+			</div>
+			<div class="plugin-card-bottom">
+				<div class="vers column-rating">
+					<?php
+					wp_star_rating(
+						array(
+							'rating' => $plugin['rating'],
+							'type'   => 'percent',
+							'number' => $plugin['num_ratings'],
+						)
+					);
+					?>
+					<span class="num-ratings" aria-hidden="true">(<?php echo number_format_i18n( $plugin['num_ratings'] ); ?>)</span>
+				</div>
+				<div class="column-updated">
+					<strong><?php _e( 'Last Updated:' ); ?></strong>
+					<?php
+						/* translators: %s: Human-readable time difference. */
+						printf( __( '%s ago' ), human_time_diff( $last_updated_timestamp ) );
+					?>
+				</div>
+				<div class="column-downloaded">
+					<?php
+					if ( $plugin['active_installs'] >= 1000000 ) {
+						$active_installs_millions = floor( $plugin['active_installs'] / 1000000 );
+						$active_installs_text     = sprintf(
+							/* translators: %s: Number of millions. */
+							_nx( '%s+ Million', '%s+ Million', $active_installs_millions, 'Active plugin installations' ),
+							number_format_i18n( $active_installs_millions )
+						);
+					} elseif ( 0 === $plugin['active_installs'] ) {
+						$active_installs_text = _x( 'Less Than 10', 'Active plugin installations' );
+					} else {
+						$active_installs_text = number_format_i18n( $plugin['active_installs'] ) . '+';
+					}
+					/* translators: %s: Number of installations. */
+					printf( __( '%s Active Installations' ), $active_installs_text );
+					?>
+				</div>
+				<div class="column-compatibility">
+					<?php
+					if ( ! $tested_wp ) {
+						echo '<span class="compatibility-untested">' . __( 'Untested with your version of WordPress' ) . '</span>';
+					} elseif ( ! $compatible_wp ) {
+						echo '<span class="compatibility-incompatible">' . __( '<strong>Incompatible</strong> with your version of WordPress' ) . '</span>';
+					} else {
+						echo '<span class="compatibility-compatible">' . __( '<strong>Compatible</strong> with your version of WordPress' ) . '</span>';
+					}
+					?>
+				</div>
+			</div>
+		</div>
+			<?php
+		}
+
+		// Close off the group divs of the last one.
+		if ( ! empty( $group ) ) {
+			echo '</div></div>';
+		}
+	}
+}

--- a/tests/fixtures/Command/FormatPhp/wordpress/class-wp-plugin-install-list-table.out
+++ b/tests/fixtures/Command/FormatPhp/wordpress/class-wp-plugin-install-list-table.out
@@ -1,0 +1,829 @@
+<?php
+/**
+ * List Table API: WP_Plugin_Install_List_Table class
+ *
+ * @package WordPress
+ * @subpackage Administration
+ * @since 3.1.0
+ */
+
+/**
+ * Core class used to implement displaying plugins to install in a list table.
+ *
+ * @since 3.1.0
+ *
+ * @see WP_List_Table
+ */
+class WP_Plugin_Install_List_Table extends WP_List_Table {
+
+	public $order   = 'ASC';
+	public $orderby = null;
+	public $groups  = array();
+
+	private $error;
+
+	/**
+	 * @return bool
+	 */
+	public function ajax_user_can() {
+		return current_user_can( 'install_plugins' );
+	}
+
+	/**
+	 * Returns the list of known plugins.
+	 *
+	 * Uses the transient data from the updates API to determine the known
+	 * installed plugins.
+	 *
+	 * @since 4.9.0
+	 * @access protected
+	 *
+	 * @return array
+	 */
+	protected function get_installed_plugins() {
+		$plugins = array();
+
+		$plugin_info = get_site_transient( 'update_plugins' );
+		if ( isset( $plugin_info->no_update ) ) {
+			foreach ( $plugin_info->no_update as $plugin ) {
+				if ( isset( $plugin->slug ) ) {
+					$plugin->upgrade          = false;
+					$plugins[ $plugin->slug ] = $plugin;
+				}
+			}
+		}
+
+		if ( isset( $plugin_info->response ) ) {
+			foreach ( $plugin_info->response as $plugin ) {
+				if ( isset( $plugin->slug ) ) {
+					$plugin->upgrade          = true;
+					$plugins[ $plugin->slug ] = $plugin;
+				}
+			}
+		}
+
+		return $plugins;
+	}
+
+	/**
+	 * Returns a list of slugs of installed plugins, if known.
+	 *
+	 * Uses the transient data from the updates API to determine the slugs of
+	 * known installed plugins. This might be better elsewhere, perhaps even
+	 * within get_plugins().
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	protected function get_installed_plugin_slugs() {
+		return array_keys( $this->get_installed_plugins() );
+	}
+
+	/**
+	 * @global array  $tabs
+	 * @global string $tab
+	 * @global int    $paged
+	 * @global string $type
+	 * @global string $term
+	 */
+	public function prepare_items() {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		global $tabs, $tab, $paged, $type, $term;
+
+		wp_reset_vars( array( 'tab' ) );
+
+		$paged = $this->get_pagenum();
+
+		$per_page = 36;
+
+		// These are the tabs which are shown on the page.
+		$tabs = array();
+
+		if ( 'search' === $tab ) {
+			$tabs['search'] = __( 'Search Results' );
+		}
+
+		if ( 'beta' === $tab || str_contains( get_bloginfo( 'version' ), '-' ) ) {
+			$tabs['beta'] = _x( 'Beta Testing', 'Plugin Installer' );
+		}
+
+		$tabs['featured']    = _x( 'Featured', 'Plugin Installer' );
+		$tabs['popular']     = _x( 'Popular', 'Plugin Installer' );
+		$tabs['recommended'] = _x( 'Recommended', 'Plugin Installer' );
+		$tabs['favorites']   = _x( 'Favorites', 'Plugin Installer' );
+
+		if ( current_user_can( 'upload_plugins' ) ) {
+			/*
+			 * No longer a real tab. Here for filter compatibility.
+			 * Gets skipped in get_views().
+			 */
+			$tabs['upload'] = __( 'Upload Plugin' );
+		}
+
+		$nonmenu_tabs = array( 'plugin-information' ); // Valid actions to perform which do not have a Menu item.
+
+		/**
+		 * Filters the tabs shown on the Add Plugins screen.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param string[] $tabs The tabs shown on the Add Plugins screen. Defaults include
+		 *                       'featured', 'popular', 'recommended', 'favorites', and 'upload'.
+		 */
+		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
+
+		/**
+		 * Filters tabs not associated with a menu item on the Add Plugins screen.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param string[] $nonmenu_tabs The tabs that don't have a menu item on the Add Plugins screen.
+		 */
+		$nonmenu_tabs = apply_filters( 'install_plugins_nonmenu_tabs', $nonmenu_tabs );
+
+		// If a non-valid menu tab has been selected, And it's not a non-menu action.
+		if ( empty( $tab ) || ( ! isset( $tabs[ $tab ] ) && ! in_array( $tab, (array) $nonmenu_tabs, true ) ) ) {
+			$tab = key( $tabs );
+		}
+
+		$installed_plugins = $this->get_installed_plugins();
+
+		$args = array(
+			'page'     => $paged,
+			'per_page' => $per_page,
+			// Send the locale to the API so it can provide context-sensitive results.
+			'locale'   => get_user_locale(),
+		);
+
+		switch ( $tab ) {
+			case 'search':
+				$type = isset( $_REQUEST['type'] ) ? wp_unslash( $_REQUEST['type'] ) : 'term';
+				$term = isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : '';
+
+				switch ( $type ) {
+					case 'tag':
+						$args['tag'] = sanitize_title_with_dashes( $term );
+						break;
+					case 'term':
+						$args['search'] = $term;
+						break;
+					case 'author':
+						$args['author'] = $term;
+						break;
+				}
+
+				break;
+
+			case 'featured':
+			case 'popular':
+			case 'new':
+			case 'beta':
+				$args['browse'] = $tab;
+				break;
+			case 'recommended':
+				$args['browse']            = $tab;
+				// Include the list of installed plugins so we can get relevant results.
+				$args['installed_plugins'] = array_keys( $installed_plugins );
+				break;
+
+			case 'favorites':
+				$action = 'save_wporg_username_' . get_current_user_id();
+				if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), $action ) ) {
+					$user = isset( $_GET['user'] ) ? wp_unslash( $_GET['user'] ) : get_user_option( 'wporg_favorites' );
+
+					// If the save url parameter is passed with a falsey value, don't save the favorite user.
+					if ( ! isset( $_GET['save'] ) || $_GET['save'] ) {
+						update_user_meta( get_current_user_id(), 'wporg_favorites', $user );
+					}
+				} else {
+					$user = get_user_option( 'wporg_favorites' );
+				}
+				if ( $user ) {
+					$args['user'] = $user;
+				} else {
+					$args = false;
+				}
+
+				add_action( 'install_plugins_favorites', 'install_plugins_favorites_form', 9, 0 );
+				break;
+
+			default:
+				$args = false;
+				break;
+		}
+
+		/**
+		 * Filters API request arguments for each Add Plugins screen tab.
+		 *
+		 * The dynamic portion of the hook name, `$tab`, refers to the plugin install tabs.
+		 *
+		 * Possible hook names include:
+		 *
+		 *  - `install_plugins_table_api_args_favorites`
+		 *  - `install_plugins_table_api_args_featured`
+		 *  - `install_plugins_table_api_args_popular`
+		 *  - `install_plugins_table_api_args_recommended`
+		 *  - `install_plugins_table_api_args_upload`
+		 *  - `install_plugins_table_api_args_search`
+		 *  - `install_plugins_table_api_args_beta`
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param array|false $args Plugin install API arguments.
+		 */
+		$args = apply_filters( "install_plugins_table_api_args_{$tab}", $args );
+
+		if ( ! $args ) {
+			return;
+		}
+
+		$api = plugins_api( 'query_plugins', $args );
+
+		if ( is_wp_error( $api ) ) {
+			$this->error = $api;
+			return;
+		}
+
+		$this->items = $api->plugins;
+
+		if ( $this->orderby ) {
+			uasort( $this->items, array( $this, 'order_callback' ) );
+		}
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $api->info['results'],
+				'per_page'    => $args['per_page'],
+			)
+		);
+
+		if ( isset( $api->info['groups'] ) ) {
+			$this->groups = $api->info['groups'];
+		}
+
+		if ( $installed_plugins ) {
+			$js_plugins = array_fill_keys(
+				array( 'all', 'search', 'active', 'inactive', 'recently_activated', 'mustuse', 'dropins' ),
+				array()
+			);
+
+			$js_plugins['all'] = array_values( wp_list_pluck( $installed_plugins, 'plugin' ) );
+			$upgrade_plugins   = wp_filter_object_list( $installed_plugins, array( 'upgrade' => true ), 'and', 'plugin' );
+
+			if ( $upgrade_plugins ) {
+				$js_plugins['upgrade'] = array_values( $upgrade_plugins );
+			}
+
+			wp_localize_script(
+				'updates',
+				'_wpUpdatesItemCounts',
+				array(
+					'plugins' => $js_plugins,
+					'totals'  => wp_get_update_data(),
+				)
+			);
+		}
+	}
+
+	public function no_items() {
+		if ( isset( $this->error ) ) {
+			$error_message  = '<p>' . $this->error->get_error_message() . '</p>';
+			$error_message .= '<p class="hide-if-no-js"><button class="button try-again">' . __( 'Try Again' ) . '</button></p>';
+			wp_admin_notice(
+				$error_message,
+				array(
+					'additional_classes' => array( 'inline', 'error' ),
+					'paragraph_wrap'     => false,
+				)
+			);
+?>
+		<?php } else { ?>
+			<div class="no-plugin-results"><?php _e( 'No plugins found. Try a different search.' ); ?></div>
+			<?php
+		}
+	}
+
+	/**
+	 * @global array $tabs
+	 * @global string $tab
+	 *
+	 * @return array
+	 */
+	protected function get_views() {
+		global $tabs, $tab;
+
+		$display_tabs = array();
+		foreach ( (array) $tabs as $action => $text ) {
+			$display_tabs[ 'plugin-install-' . $action ] = array(
+				'url'     => self_admin_url( 'plugin-install.php?tab=' . $action ),
+				'label'   => $text,
+				'current' => $action === $tab,
+			);
+		}
+		// No longer a real tab.
+		unset( $display_tabs['plugin-install-upload'] );
+
+		return $this->get_views_links( $display_tabs );
+	}
+
+	/**
+	 * Overrides parent views so we can use the filter bar display.
+	 */
+	public function views() {
+		$views = $this->get_views();
+
+		/** This filter is documented in wp-admin/includes/class-wp-list-table.php */
+		$views = apply_filters( "views_{$this->screen->id}", $views );
+
+		$this->screen->render_screen_reader_content( 'heading_views' );
+			?>
+<div class="wp-filter">
+	<ul class="filter-links">
+		<?php
+		if ( ! empty( $views ) ) {
+			foreach ( $views as $class => $view ) {
+				$views[ $class ] = "	<li class='$class'>$view";
+			}
+			echo implode( " </li>\n", $views ) . "</li>\n";
+		}
+		?>
+	</ul>
+
+		<?php install_search_form(); ?>
+</div>
+		<?php
+	}
+
+	/**
+	 * Displays the plugin install table.
+	 *
+	 * Overrides the parent display() method to provide a different container.
+	 *
+	 * @since 4.0.0
+	 */
+	public function display() {
+		$singular = $this->_args['singular'];
+
+		$data_attr = '';
+
+		if ( $singular ) {
+			$data_attr = " data-wp-lists='list:$singular'";
+		}
+
+		$this->display_tablenav( 'top' );
+
+		?>
+<div class="wp-list-table <?php echo implode( ' ', $this->get_table_classes() ); ?>">
+		<?php
+		$this->screen->render_screen_reader_content( 'heading_list' );
+		?>
+	<div id="the-list"<?php echo $data_attr; ?>>
+		<?php $this->display_rows_or_placeholder(); ?>
+	</div>
+</div>
+		<?php
+		$this->display_tablenav( 'bottom' );
+	}
+
+	/**
+	 * @global string $tab
+	 *
+	 * @param string $which
+	 */
+	protected function display_tablenav( $which ) {
+		if ( 'featured' === $GLOBALS['tab'] ) {
+			return;
+		}
+
+		if ( 'top' === $which ) {
+			wp_referer_field();
+			?>
+			<div class="tablenav top">
+				<div class="alignleft actions">
+					<?php
+					/**
+					 * Fires before the Plugin Install table header pagination is displayed.
+					 *
+					 * @since 2.7.0
+					 */
+					do_action( 'install_plugins_table_header' );
+					?>
+				</div>
+				<?php $this->pagination( $which ); ?>
+				<br class="clear" />
+			</div>
+		<?php } else { ?>
+			<div class="tablenav bottom">
+				<?php $this->pagination( $which ); ?>
+				<br class="clear" />
+			</div>
+			<?php
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function get_table_classes() {
+		return array( 'widefat', $this->_args['plural'] );
+	}
+
+	/**
+	 * @return string[] Array of column titles keyed by their column name.
+	 */
+	public function get_columns() {
+		return array();
+	}
+
+	/**
+	 * @param object $plugin_a
+	 * @param object $plugin_b
+	 * @return int
+	 */
+	private function order_callback( $plugin_a, $plugin_b ) {
+		$orderby = $this->orderby;
+		if ( ! isset( $plugin_a->$orderby, $plugin_b->$orderby ) ) {
+			return 0;
+		}
+
+		$a = $plugin_a->$orderby;
+		$b = $plugin_b->$orderby;
+
+		if ( $a === $b ) {
+			return 0;
+		}
+
+		if ( 'DESC' === $this->order ) {
+			return ( $a < $b ) ? 1 : -1;
+		} else {
+			return ( $a < $b ) ? -1 : 1;
+		}
+	}
+
+	public function display_rows() {
+		$plugins_allowedtags = array(
+			'a'       => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'abbr'    => array( 'title' => array() ),
+			'acronym' => array( 'title' => array() ),
+			'code'    => array(),
+			'pre'     => array(),
+			'em'      => array(),
+			'strong'  => array(),
+			'ul'      => array(),
+			'ol'      => array(),
+			'li'      => array(),
+			'p'       => array(),
+			'br'      => array(),
+		);
+
+		$plugins_group_titles = array(
+			'Performance' => _x( 'Performance', 'Plugin installer group title' ),
+			'Social'      => _x( 'Social', 'Plugin installer group title' ),
+			'Tools'       => _x( 'Tools', 'Plugin installer group title' ),
+		);
+
+		$group = null;
+
+		foreach ( (array) $this->items as $plugin ) {
+			if ( is_object( $plugin ) ) {
+				$plugin = (array) $plugin;
+			}
+
+			// Display the group heading if there is one.
+			if ( isset( $plugin['group'] ) && $plugin['group'] !== $group ) {
+				if ( isset( $this->groups[ $plugin['group'] ] ) ) {
+					$group_name = $this->groups[ $plugin['group'] ];
+					if ( isset( $plugins_group_titles[ $group_name ] ) ) {
+						$group_name = $plugins_group_titles[ $group_name ];
+					}
+				} else {
+					$group_name = $plugin['group'];
+				}
+
+				// Starting a new group, close off the divs of the last one.
+				if ( ! empty( $group ) ) {
+					echo '</div></div>';
+				}
+
+				echo '<div class="plugin-group"><h3>' . esc_html( $group_name ) . '</h3>';
+				// Needs an extra wrapping div for nth-child selectors to work.
+				echo '<div class="plugin-items">';
+
+				$group = $plugin['group'];
+			}
+
+			$title = wp_kses( $plugin['name'], $plugins_allowedtags );
+
+			// Remove any HTML from the description.
+			$description = strip_tags( $plugin['short_description'] );
+
+			/**
+			 * Filters the plugin card description on the Add Plugins screen.
+			 *
+			 * @since 6.0.0
+			 *
+			 * @param string $description Plugin card description.
+			 * @param array  $plugin      An array of plugin data. See {@see plugins_api()}
+			 *                            for the list of possible values.
+			 */
+			$description = apply_filters( 'plugin_install_description', $description, $plugin );
+
+			$version = wp_kses( $plugin['version'], $plugins_allowedtags );
+
+			$name = strip_tags( $title . ' ' . $version );
+
+			$author = wp_kses( $plugin['author'], $plugins_allowedtags );
+			if ( ! empty( $author ) ) {
+				/* translators: %s: Plugin author. */
+				$author = ' <cite>' . sprintf( __( 'By %s' ), $author ) . '</cite>';
+			}
+
+			$requires_php = isset( $plugin['requires_php'] ) ? $plugin['requires_php'] : null;
+			$requires_wp  = isset( $plugin['requires'] ) ? $plugin['requires'] : null;
+
+			$compatible_php = is_php_version_compatible( $requires_php );
+			$compatible_wp  = is_wp_version_compatible( $requires_wp );
+			$tested_wp      = ( empty( $plugin['tested'] ) || version_compare( get_bloginfo( 'version' ), $plugin['tested'], '<=' ) );
+
+			$action_links = array();
+
+			if ( current_user_can( 'install_plugins' ) || current_user_can( 'update_plugins' ) ) {
+				$status = install_plugin_install_status( $plugin );
+
+				switch ( $status['status'] ) {
+					case 'install':
+						if ( $status['url'] ) {
+							if ( $compatible_php && $compatible_wp ) {
+								$action_links[] = sprintf(
+									'<a class="install-now button" data-slug="%s" href="%s" aria-label="%s" data-name="%s">%s</a>',
+									esc_attr( $plugin['slug'] ),
+									esc_url( $status['url'] ),
+									/* translators: %s: Plugin name and version. */
+									esc_attr( sprintf( _x( 'Install %s now', 'plugin' ), $name ) ),
+									esc_attr( $name ),
+									__( 'Install Now' )
+								);
+							} else {
+								$action_links[] = sprintf(
+									'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+									_x( 'Cannot Install', 'plugin' )
+								);
+							}
+						}
+						break;
+
+					case 'update_available':
+						if ( $status['url'] ) {
+							if ( $compatible_php && $compatible_wp ) {
+								$action_links[] = sprintf(
+									'<a class="update-now button aria-button-if-js" data-plugin="%s" data-slug="%s" href="%s" aria-label="%s" data-name="%s">%s</a>',
+									esc_attr( $status['file'] ),
+									esc_attr( $plugin['slug'] ),
+									esc_url( $status['url'] ),
+									/* translators: %s: Plugin name and version. */
+									esc_attr( sprintf( _x( 'Update %s now', 'plugin' ), $name ) ),
+									esc_attr( $name ),
+									__( 'Update Now' )
+								);
+							} else {
+								$action_links[] = sprintf(
+									'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+									_x( 'Cannot Update', 'plugin' )
+								);
+							}
+						}
+						break;
+
+					case 'latest_installed':
+					case 'newer_installed':
+						if ( is_plugin_active( $status['file'] ) ) {
+							$action_links[] = sprintf(
+								'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+								_x( 'Active', 'plugin' )
+							);
+						} elseif ( current_user_can( 'activate_plugin', $status['file'] ) ) {
+							if ( $compatible_php && $compatible_wp ) {
+								$button_text  = __( 'Activate' );
+								/* translators: %s: Plugin name. */
+								$button_label = _x( 'Activate %s', 'plugin' );
+								$activate_url = add_query_arg(
+									array(
+										'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $status['file'] ),
+										'action'   => 'activate',
+										'plugin'   => $status['file'],
+									),
+									network_admin_url( 'plugins.php' )
+								);
+
+								if ( is_network_admin() ) {
+									$button_text  = __( 'Network Activate' );
+									/* translators: %s: Plugin name. */
+									$button_label = _x( 'Network Activate %s', 'plugin' );
+									$activate_url = add_query_arg( array( 'networkwide' => 1 ), $activate_url );
+								}
+
+								$action_links[] = sprintf(
+									'<a href="%1$s" class="button activate-now" aria-label="%2$s">%3$s</a>',
+									esc_url( $activate_url ),
+									esc_attr( sprintf( $button_label, $plugin['name'] ) ),
+									$button_text
+								);
+							} else {
+								$action_links[] = sprintf(
+									'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+									_x( 'Cannot Activate', 'plugin' )
+								);
+							}
+						} else {
+							$action_links[] = sprintf(
+								'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+								_x( 'Installed', 'plugin' )
+							);
+						}
+						break;
+				}
+			}
+
+			$details_link = self_admin_url(
+				'plugin-install.php?tab=plugin-information&amp;plugin=' . $plugin['slug'] .
+				'&amp;TB_iframe=true&amp;width=600&amp;height=550'
+			);
+
+			$action_links[] = sprintf(
+				'<a href="%s" class="thickbox open-plugin-details-modal" aria-label="%s" data-title="%s">%s</a>',
+				esc_url( $details_link ),
+				/* translators: %s: Plugin name and version. */
+				esc_attr( sprintf( __( 'More information about %s' ), $name ) ),
+				esc_attr( $name ),
+				__( 'More Details' )
+			);
+
+			if ( ! empty( $plugin['icons']['svg'] ) ) {
+				$plugin_icon_url = $plugin['icons']['svg'];
+			} elseif ( ! empty( $plugin['icons']['2x'] ) ) {
+				$plugin_icon_url = $plugin['icons']['2x'];
+			} elseif ( ! empty( $plugin['icons']['1x'] ) ) {
+				$plugin_icon_url = $plugin['icons']['1x'];
+			} else {
+				$plugin_icon_url = $plugin['icons']['default'];
+			}
+
+			/**
+			 * Filters the install action links for a plugin.
+			 *
+			 * @since 2.7.0
+			 *
+			 * @param string[] $action_links An array of plugin action links.
+			 *                               Defaults are links to Details and Install Now.
+			 * @param array    $plugin       An array of plugin data. See {@see plugins_api()}
+			 *                               for the list of possible values.
+			 */
+			$action_links = apply_filters( 'plugin_install_action_links', $action_links, $plugin );
+
+			$last_updated_timestamp = strtotime( $plugin['last_updated'] );
+			?>
+		<div class="plugin-card plugin-card-<?php echo sanitize_html_class( $plugin['slug'] ); ?>">
+			<?php
+			if ( ! $compatible_php || ! $compatible_wp ) {
+				$incompatible_notice_message = '';
+				if ( ! $compatible_php && ! $compatible_wp ) {
+					$incompatible_notice_message .= __( 'This plugin does not work with your versions of WordPress and PHP.' );
+					if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+							' ' . __( '<a href="%1$s">Please update WordPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
+						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
+					} elseif ( current_user_can( 'update_core' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: %s: URL to WordPress Updates screen. */
+							' ' . __( '<a href="%s">Please update WordPress</a>.' ),
+							self_admin_url( 'update-core.php' )
+						);
+					} elseif ( current_user_can( 'update_php' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);
+						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
+					}
+				} elseif ( ! $compatible_wp ) {
+					$incompatible_notice_message .= __( 'This plugin does not work with your version of WordPress.' );
+					if ( current_user_can( 'update_core' ) ) {
+						$incompatible_notice_message .= printf(
+							/* translators: %s: URL to WordPress Updates screen. */
+							' ' . __( '<a href="%s">Please update WordPress</a>.' ),
+							self_admin_url( 'update-core.php' )
+						);
+					}
+				} elseif ( ! $compatible_php ) {
+					$incompatible_notice_message .= __( 'This plugin does not work with your version of PHP.' );
+					if ( current_user_can( 'update_php' ) ) {
+						$incompatible_notice_message .= sprintf(
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);
+						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
+					}
+				}
+
+				wp_admin_notice(
+					$incompatible_notice_message,
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt', 'inline' ),
+					)
+				);
+			}
+			?>
+			<div class="plugin-card-top">
+				<div class="name column-name">
+					<h3>
+						<a href="<?php echo esc_url( $details_link ); ?>" class="thickbox open-plugin-details-modal">
+						<?php echo $title; ?>
+						<img src="<?php echo esc_url( $plugin_icon_url ); ?>" class="plugin-icon" alt="" />
+						</a>
+					</h3>
+				</div>
+				<div class="action-links">
+					<?php
+					if ( $action_links ) {
+						echo '<ul class="plugin-action-buttons"><li>' . implode( '</li><li>', $action_links ) . '</li></ul>';
+					}
+					?>
+				</div>
+				<div class="desc column-description">
+					<p><?php echo $description; ?></p>
+					<p class="authors"><?php echo $author; ?></p>
+				</div>
+			</div>
+			<div class="plugin-card-bottom">
+				<div class="vers column-rating">
+					<?php
+					wp_star_rating(
+						array(
+							'rating' => $plugin['rating'],
+							'type'   => 'percent',
+							'number' => $plugin['num_ratings'],
+						)
+					);
+					?>
+					<span class="num-ratings" aria-hidden="true">(<?php echo number_format_i18n( $plugin['num_ratings'] ); ?>)</span>
+				</div>
+				<div class="column-updated">
+					<strong><?php _e( 'Last Updated:' ); ?></strong>
+					<?php
+					/* translators: %s: Human-readable time difference. */
+					printf( __( '%s ago' ), human_time_diff( $last_updated_timestamp ) );
+					?>
+				</div>
+				<div class="column-downloaded">
+					<?php
+					if ( $plugin['active_installs'] >= 1000000 ) {
+						$active_installs_millions = floor( $plugin['active_installs'] / 1000000 );
+						$active_installs_text     = sprintf(
+							/* translators: %s: Number of millions. */
+							_nx( '%s+ Million', '%s+ Million', $active_installs_millions, 'Active plugin installations' ),
+							number_format_i18n( $active_installs_millions )
+						);
+					} elseif ( 0 === $plugin['active_installs'] ) {
+						$active_installs_text = _x( 'Less Than 10', 'Active plugin installations' );
+					} else {
+						$active_installs_text = number_format_i18n( $plugin['active_installs'] ) . '+';
+					}
+					/* translators: %s: Number of installations. */
+					printf( __( '%s Active Installations' ), $active_installs_text );
+					?>
+				</div>
+				<div class="column-compatibility">
+					<?php
+					if ( ! $tested_wp ) {
+						echo '<span class="compatibility-untested">' . __( 'Untested with your version of WordPress' ) . '</span>';
+					} elseif ( ! $compatible_wp ) {
+						echo '<span class="compatibility-incompatible">' . __( '<strong>Incompatible</strong> with your version of WordPress' ) . '</span>';
+					} else {
+						echo '<span class="compatibility-compatible">' . __( '<strong>Compatible</strong> with your version of WordPress' ) . '</span>';
+					}
+					?>
+				</div>
+			</div>
+		</div>
+			<?php
+		}
+
+		// Close off the group divs of the last one.
+		if ( ! empty( $group ) ) {
+			echo '</div></div>';
+		}
+	}
+}

--- a/tests/fixtures/Command/FormatPhp/wordpress/loop.in
+++ b/tests/fixtures/Command/FormatPhp/wordpress/loop.in
@@ -1,0 +1,211 @@
+<?php
+/**
+ * The loop that displays posts
+ *
+ * The loop displays the posts and the post content. See
+ * https://developer.wordpress.org/themes/basics/the-loop/ to understand it and
+ * https://developer.wordpress.org/themes/basics/template-tags/ to understand
+ * the tags used in it.
+ *
+ * This can be overridden in child themes with loop.php or
+ * loop-template.php, where 'template' is the loop context
+ * requested by a template. For example, loop-index.php would
+ * be used if it exists and we ask for the loop with:
+ * <code>get_template_part( 'loop', 'index' );</code>
+ *
+ * @package WordPress
+ * @subpackage Twenty_Ten
+ * @since Twenty Ten 1.0
+ */
+?>
+
+<?php // Display navigation to next/previous pages when applicable. ?>
+<?php if ( $wp_query->max_num_pages > 1 ) : ?>
+	<div id="nav-above" class="navigation">
+		<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', 'twentyten' ) ); ?></div>
+		<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?></div>
+	</div><!-- #nav-above -->
+<?php endif; ?>
+
+<?php /* If there are no posts to display, such as an empty archive page */ ?>
+<?php if ( ! have_posts() ) : ?>
+	<div id="post-0" class="post error404 not-found">
+		<h1 class="entry-title"><?php _e( 'Not Found', 'twentyten' ); ?></h1>
+		<div class="entry-content">
+			<p><?php _e( 'Apologies, but no results were found for the requested archive. Perhaps searching will help find a related post.', 'twentyten' ); ?></p>
+			<?php get_search_form(); ?>
+		</div><!-- .entry-content -->
+	</div><!-- #post-0 -->
+<?php endif; ?>
+
+<?php
+	/*
+	 * Start the Loop.
+	 *
+	 * In Twenty Ten we use the same loop in multiple contexts.
+	 * It is broken into three main parts: when we're displaying
+	 * posts that are in the gallery category, when we're displaying
+	 * posts in the asides category, and finally all other posts.
+	 *
+	 * Additionally, we sometimes check for whether we are on an
+	 * archive page, a search page, etc., allowing for small differences
+	 * in the loop on each template without actually duplicating
+	 * the rest of the loop that is shared.
+	 *
+	 * Without further ado, the loop:
+	 */
+?>
+<?php
+while ( have_posts() ) :
+	the_post();
+	?>
+
+	<?php /* How to display posts of the Gallery format. The gallery category is the old way. */ ?>
+
+	<?php if ( ( function_exists( 'get_post_format' ) && 'gallery' === get_post_format( $post->ID ) ) || in_category( _x( 'gallery', 'gallery category slug', 'twentyten' ) ) ) : ?>
+		<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<h2 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
+
+			<div class="entry-meta">
+				<?php twentyten_posted_on(); ?>
+			</div><!-- .entry-meta -->
+
+			<div class="entry-content">
+		<?php if ( post_password_required() ) : ?>
+				<?php the_content(); ?>
+<?php else : ?>
+				<?php
+					$images = twentyten_get_gallery_images();
+				if ( $images ) :
+					$total_images = count( $images );
+					$image        = reset( $images );
+					?>
+					<div class="gallery-thumb">
+						<a class="size-thumbnail" href="<?php the_permalink(); ?>"><?php echo wp_get_attachment_image( $image, 'thumbnail' ); ?></a>
+					</div><!-- .gallery-thumb -->
+					<p><em>
+					<?php
+						printf(
+							/* translators: 1: HTML tag attributes, 2: Image count. */
+							_n( 'This gallery contains <a %1$s>%2$s photo</a>.', 'This gallery contains <a %1$s>%2$s photos</a>.', $total_images, 'twentyten' ),
+							/* translators: %s: Post title. */
+							'href="' . esc_url( get_permalink() ) . '" title="' . esc_attr( sprintf( __( 'Permalink to %s', 'twentyten' ), the_title_attribute( 'echo=0' ) ) ) . '" rel="bookmark"',
+							number_format_i18n( $total_images )
+						);
+					?>
+							</em></p>
+				<?php endif; // End twentyten_get_gallery_images() check. ?>
+						<?php the_excerpt(); ?>
+<?php endif; ?>
+			</div><!-- .entry-content -->
+
+			<div class="entry-utility">
+			<?php
+			$gallery = get_term_by( 'slug', _x( 'gallery', 'gallery category slug', 'twentyten' ), 'category' );
+			if ( function_exists( 'get_post_format' ) && 'gallery' === get_post_format( $post->ID ) ) :
+				?>
+				<a href="<?php echo esc_url( get_post_format_link( 'gallery' ) ); ?>" title="<?php esc_attr_e( 'View Galleries', 'twentyten' ); ?>"><?php _e( 'More Galleries', 'twentyten' ); ?></a>
+				<span class="meta-sep">|</span>
+			<?php elseif ( $gallery && in_category( $gallery->term_id ) ) : ?>
+				<a href="<?php echo esc_url( get_category_link( $gallery ) ); ?>" title="<?php esc_attr_e( 'View posts in the Gallery category', 'twentyten' ); ?>"><?php _e( 'More Galleries', 'twentyten' ); ?></a>
+				<span class="meta-sep">|</span>
+			<?php endif; ?>
+				<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'twentyten' ), __( '1 Comment', 'twentyten' ), __( '% Comments', 'twentyten' ) ); ?></span>
+				<?php edit_post_link( __( 'Edit', 'twentyten' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+			</div><!-- .entry-utility -->
+		</div><!-- #post-<?php the_ID(); ?> -->
+
+		<?php /* How to display posts of the Aside format. The asides category is the old way. */ ?>
+
+	<?php elseif ( ( function_exists( 'get_post_format' ) && 'aside' === get_post_format( $post->ID ) ) || in_category( _x( 'asides', 'asides category slug', 'twentyten' ) ) ) : ?>
+		<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+		<?php if ( is_archive() || is_search() ) : // Display excerpts for archives and search. ?>
+			<div class="entry-summary">
+				<?php the_excerpt(); ?>
+			</div><!-- .entry-summary -->
+		<?php else : ?>
+			<div class="entry-content">
+				<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?>
+			</div><!-- .entry-content -->
+		<?php endif; ?>
+
+			<div class="entry-utility">
+				<?php twentyten_posted_on(); ?>
+				<span class="meta-sep">|</span>
+				<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'twentyten' ), __( '1 Comment', 'twentyten' ), __( '% Comments', 'twentyten' ) ); ?></span>
+				<?php edit_post_link( __( 'Edit', 'twentyten' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+			</div><!-- .entry-utility -->
+		</div><!-- #post-<?php the_ID(); ?> -->
+
+		<?php /* How to display all other posts. */ ?>
+
+	<?php else : ?>
+		<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<h2 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
+
+			<div class="entry-meta">
+				<?php twentyten_posted_on(); ?>
+			</div><!-- .entry-meta -->
+
+		<?php if ( is_archive() || is_search() ) : // Only display excerpts for archives and search. ?>
+			<div class="entry-summary">
+				<?php the_excerpt(); ?>
+			</div><!-- .entry-summary -->
+	<?php else : ?>
+			<div class="entry-content">
+				<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?>
+				<?php
+				wp_link_pages(
+					array(
+						'before' => '<div class="page-link">' . __( 'Pages:', 'twentyten' ),
+						'after'  => '</div>',
+					)
+				);
+				?>
+			</div><!-- .entry-content -->
+	<?php endif; ?>
+
+			<div class="entry-utility">
+				<?php if ( count( get_the_category() ) ) : ?>
+					<span class="cat-links">
+						<?php
+						/* translators: 1: CSS classes, 2: Category list. */
+						printf( __( '<span class="%1$s">Posted in</span> %2$s', 'twentyten' ), 'entry-utility-prep entry-utility-prep-cat-links', get_the_category_list( ', ' ) );
+						?>
+					</span>
+					<span class="meta-sep">|</span>
+				<?php endif; ?>
+
+				<?php
+				$tags_list = get_the_tag_list( '', ', ' );
+				if ( $tags_list && ! is_wp_error( $tags_list ) ) :
+					?>
+				<span class="tag-links">
+					<?php
+					/* translators: 1: CSS classes, 2: Category list. */
+					printf( __( '<span class="%1$s">Tagged</span> %2$s', 'twentyten' ), 'entry-utility-prep entry-utility-prep-tag-links', $tags_list );
+					?>
+				</span>
+				<span class="meta-sep">|</span>
+				<?php endif; ?>
+
+				<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'twentyten' ), __( '1 Comment', 'twentyten' ), __( '% Comments', 'twentyten' ) ); ?></span>
+
+				<?php edit_post_link( __( 'Edit', 'twentyten' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+			</div><!-- .entry-utility -->
+		</div><!-- #post-<?php the_ID(); ?> -->
+
+		<?php comments_template( '', true ); ?>
+
+	<?php endif; // This was the if statement that broke the loop into three parts based on categories. ?>
+
+<?php endwhile; // End of the loop. Whew. ?>
+
+<?php // Display navigation to next/previous pages when applicable. ?>
+<?php if ( $wp_query->max_num_pages > 1 ) : ?>
+				<div id="nav-below" class="navigation">
+					<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', 'twentyten' ) ); ?></div>
+					<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?></div>
+				</div><!-- #nav-below -->
+<?php endif; ?>

--- a/tests/fixtures/Command/FormatPhp/wordpress/loop.out
+++ b/tests/fixtures/Command/FormatPhp/wordpress/loop.out
@@ -1,0 +1,211 @@
+<?php
+/**
+ * The loop that displays posts
+ *
+ * The loop displays the posts and the post content. See
+ * https://developer.wordpress.org/themes/basics/the-loop/ to understand it and
+ * https://developer.wordpress.org/themes/basics/template-tags/ to understand
+ * the tags used in it.
+ *
+ * This can be overridden in child themes with loop.php or
+ * loop-template.php, where 'template' is the loop context
+ * requested by a template. For example, loop-index.php would
+ * be used if it exists and we ask for the loop with:
+ * <code>get_template_part( 'loop', 'index' );</code>
+ *
+ * @package WordPress
+ * @subpackage Twenty_Ten
+ * @since Twenty Ten 1.0
+ */
+?>
+
+<?php // Display navigation to next/previous pages when applicable. ?>
+<?php if ( $wp_query->max_num_pages > 1 ) : ?>
+	<div id="nav-above" class="navigation">
+		<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', 'twentyten' ) ); ?></div>
+		<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?></div>
+	</div><!-- #nav-above -->
+<?php endif; ?>
+
+<?php /* If there are no posts to display, such as an empty archive page */ ?>
+<?php if ( ! have_posts() ) : ?>
+	<div id="post-0" class="post error404 not-found">
+		<h1 class="entry-title"><?php _e( 'Not Found', 'twentyten' ); ?></h1>
+		<div class="entry-content">
+			<p><?php _e( 'Apologies, but no results were found for the requested archive. Perhaps searching will help find a related post.', 'twentyten' ); ?></p>
+			<?php get_search_form(); ?>
+		</div><!-- .entry-content -->
+	</div><!-- #post-0 -->
+<?php endif; ?>
+
+<?php
+/*
+ * Start the Loop.
+ *
+ * In Twenty Ten we use the same loop in multiple contexts.
+ * It is broken into three main parts: when we're displaying
+ * posts that are in the gallery category, when we're displaying
+ * posts in the asides category, and finally all other posts.
+ *
+ * Additionally, we sometimes check for whether we are on an
+ * archive page, a search page, etc., allowing for small differences
+ * in the loop on each template without actually duplicating
+ * the rest of the loop that is shared.
+ *
+ * Without further ado, the loop:
+ */
+?>
+<?php
+while ( have_posts() ) :
+	the_post();
+?>
+
+	<?php /* How to display posts of the Gallery format. The gallery category is the old way. */ ?>
+
+	<?php if ( ( function_exists( 'get_post_format' ) && 'gallery' === get_post_format( $post->ID ) ) || in_category( _x( 'gallery', 'gallery category slug', 'twentyten' ) ) ) : ?>
+		<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<h2 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
+
+			<div class="entry-meta">
+				<?php twentyten_posted_on(); ?>
+			</div><!-- .entry-meta -->
+
+			<div class="entry-content">
+		<?php if ( post_password_required() ) : ?>
+				<?php the_content(); ?>
+<?php else : ?>
+				<?php
+				$images = twentyten_get_gallery_images();
+				if ( $images ) :
+					$total_images = count( $images );
+					$image = reset( $images );
+					?>
+					<div class="gallery-thumb">
+						<a class="size-thumbnail" href="<?php the_permalink(); ?>"><?php echo wp_get_attachment_image( $image, 'thumbnail' ); ?></a>
+					</div><!-- .gallery-thumb -->
+					<p><em>
+					<?php
+					printf(
+						/* translators: 1: HTML tag attributes, 2: Image count. */
+						_n( 'This gallery contains <a %1$s>%2$s photo</a>.', 'This gallery contains <a %1$s>%2$s photos</a>.', $total_images, 'twentyten' ),
+						/* translators: %s: Post title. */
+						'href="' . esc_url( get_permalink() ) . '" title="' . esc_attr( sprintf( __( 'Permalink to %s', 'twentyten' ), the_title_attribute( 'echo=0' ) ) ) . '" rel="bookmark"',
+						number_format_i18n( $total_images )
+					);
+					?>
+							</em></p>
+				<?php endif; // End twentyten_get_gallery_images() check. ?>
+						<?php the_excerpt(); ?>
+<?php endif; ?>
+			</div><!-- .entry-content -->
+
+			<div class="entry-utility">
+			<?php
+			$gallery = get_term_by( 'slug', _x( 'gallery', 'gallery category slug', 'twentyten' ), 'category' );
+			if ( function_exists( 'get_post_format' ) && 'gallery' === get_post_format( $post->ID ) ) :
+				?>
+				<a href="<?php echo esc_url( get_post_format_link( 'gallery' ) ); ?>" title="<?php esc_attr_e( 'View Galleries', 'twentyten' ); ?>"><?php _e( 'More Galleries', 'twentyten' ); ?></a>
+				<span class="meta-sep">|</span>
+			<?php elseif ( $gallery && in_category( $gallery->term_id ) ) : ?>
+				<a href="<?php echo esc_url( get_category_link( $gallery ) ); ?>" title="<?php esc_attr_e( 'View posts in the Gallery category', 'twentyten' ); ?>"><?php _e( 'More Galleries', 'twentyten' ); ?></a>
+				<span class="meta-sep">|</span>
+			<?php endif; ?>
+				<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'twentyten' ), __( '1 Comment', 'twentyten' ), __( '% Comments', 'twentyten' ) ); ?></span>
+				<?php edit_post_link( __( 'Edit', 'twentyten' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+			</div><!-- .entry-utility -->
+		</div><!-- #post-<?php the_ID(); ?> -->
+
+		<?php /* How to display posts of the Aside format. The asides category is the old way. */ ?>
+
+	<?php elseif ( ( function_exists( 'get_post_format' ) && 'aside' === get_post_format( $post->ID ) ) || in_category( _x( 'asides', 'asides category slug', 'twentyten' ) ) ) : ?>
+		<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+		<?php if ( is_archive() || is_search() ) : // Display excerpts for archives and search. ?>
+			<div class="entry-summary">
+				<?php the_excerpt(); ?>
+			</div><!-- .entry-summary -->
+		<?php else : ?>
+			<div class="entry-content">
+				<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?>
+			</div><!-- .entry-content -->
+		<?php endif; ?>
+
+			<div class="entry-utility">
+				<?php twentyten_posted_on(); ?>
+				<span class="meta-sep">|</span>
+				<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'twentyten' ), __( '1 Comment', 'twentyten' ), __( '% Comments', 'twentyten' ) ); ?></span>
+				<?php edit_post_link( __( 'Edit', 'twentyten' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+			</div><!-- .entry-utility -->
+		</div><!-- #post-<?php the_ID(); ?> -->
+
+		<?php /* How to display all other posts. */ ?>
+
+	<?php else : ?>
+		<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<h2 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
+
+			<div class="entry-meta">
+				<?php twentyten_posted_on(); ?>
+			</div><!-- .entry-meta -->
+
+		<?php if ( is_archive() || is_search() ) : // Only display excerpts for archives and search. ?>
+			<div class="entry-summary">
+				<?php the_excerpt(); ?>
+			</div><!-- .entry-summary -->
+	<?php else : ?>
+			<div class="entry-content">
+				<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?>
+				<?php
+				wp_link_pages(
+					array(
+						'before' => '<div class="page-link">' . __( 'Pages:', 'twentyten' ),
+						'after'  => '</div>',
+					)
+				);
+				?>
+			</div><!-- .entry-content -->
+	<?php endif; ?>
+
+			<div class="entry-utility">
+				<?php if ( count( get_the_category() ) ) : ?>
+					<span class="cat-links">
+						<?php
+						/* translators: 1: CSS classes, 2: Category list. */
+						printf( __( '<span class="%1$s">Posted in</span> %2$s', 'twentyten' ), 'entry-utility-prep entry-utility-prep-cat-links', get_the_category_list( ', ' ) );
+						?>
+					</span>
+					<span class="meta-sep">|</span>
+				<?php endif; ?>
+
+				<?php
+				$tags_list = get_the_tag_list( '', ', ' );
+				if ( $tags_list && ! is_wp_error( $tags_list ) ) :
+				?>
+				<span class="tag-links">
+					<?php
+					/* translators: 1: CSS classes, 2: Category list. */
+					printf( __( '<span class="%1$s">Tagged</span> %2$s', 'twentyten' ), 'entry-utility-prep entry-utility-prep-tag-links', $tags_list );
+							?>
+				</span>
+				<span class="meta-sep">|</span>
+				<?php endif; ?>
+
+				<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'twentyten' ), __( '1 Comment', 'twentyten' ), __( '% Comments', 'twentyten' ) ); ?></span>
+
+				<?php edit_post_link( __( 'Edit', 'twentyten' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+			</div><!-- .entry-utility -->
+		</div><!-- #post-<?php the_ID(); ?> -->
+
+		<?php comments_template( '', true ); ?>
+
+	<?php endif; // This was the if statement that broke the loop into three parts based on categories. ?>
+
+<?php endwhile; // End of the loop. Whew. ?>
+
+<?php // Display navigation to next/previous pages when applicable. ?>
+<?php if ( $wp_query->max_num_pages > 1 ) : ?>
+				<div id="nav-below" class="navigation">
+					<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', 'twentyten' ) ); ?></div>
+					<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', 'twentyten' ) ); ?></div>
+				</div><!-- #nav-below -->
+<?php endif; ?>

--- a/tests/fixtures/Command/FormatPhp/wordpress/meta-boxes.in
+++ b/tests/fixtures/Command/FormatPhp/wordpress/meta-boxes.in
@@ -1,0 +1,1751 @@
+<?php
+/**
+ * WordPress Administration Meta Boxes API.
+ *
+ * @package WordPress
+ * @subpackage Administration
+ */
+
+//
+// Post-related Meta Boxes.
+//
+
+/**
+ * Displays post submit form fields.
+ *
+ * @since 2.7.0
+ *
+ * @global string $action
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $args {
+ *     Array of arguments for building the post submit meta box.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args     Extra meta box arguments.
+ * }
+ */
+function post_submit_meta_box( $post, $args = array() ) {
+	global $action;
+
+	$post_id          = (int) $post->ID;
+	$post_type        = $post->post_type;
+	$post_type_object = get_post_type_object( $post_type );
+	$can_publish      = current_user_can( $post_type_object->cap->publish_posts );
+	?>
+<div class="submitbox" id="submitpost">
+
+<div id="minor-publishing">
+
+	<?php // Hidden submit button early on so that the browser chooses the right button when form is submitted with Return key. ?>
+	<div style="display:none;">
+		<?php submit_button( __( 'Save' ), '', 'save' ); ?>
+	</div>
+
+	<div id="minor-publishing-actions">
+		<div id="save-action">
+			<?php
+			if ( ! in_array( $post->post_status, array( 'publish', 'future', 'pending' ), true ) ) {
+				$private_style = '';
+				if ( 'private' === $post->post_status ) {
+					$private_style = 'style="display:none"';
+				}
+				?>
+				<input <?php echo $private_style; ?> type="submit" name="save" id="save-post" value="<?php esc_attr_e( 'Save Draft' ); ?>" class="button" />
+				<span class="spinner"></span>
+			<?php } elseif ( 'pending' === $post->post_status && $can_publish ) { ?>
+				<input type="submit" name="save" id="save-post" value="<?php esc_attr_e( 'Save as Pending' ); ?>" class="button" />
+				<span class="spinner"></span>
+			<?php } ?>
+		</div>
+
+		<?php
+		if ( is_post_type_viewable( $post_type_object ) ) :
+			?>
+			<div id="preview-action">
+				<?php
+				$preview_link = esc_url( get_preview_post_link( $post ) );
+				if ( 'publish' === $post->post_status ) {
+					$preview_button_text = __( 'Preview Changes' );
+				} else {
+					$preview_button_text = __( 'Preview' );
+				}
+
+				$preview_button = sprintf(
+					'%1$s<span class="screen-reader-text"> %2$s</span>',
+					$preview_button_text,
+					/* translators: Hidden accessibility text. */
+					__( '(opens in a new tab)' )
+				);
+				?>
+				<a class="preview button" href="<?php echo $preview_link; ?>" target="wp-preview-<?php echo $post_id; ?>" id="post-preview"><?php echo $preview_button; ?></a>
+				<input type="hidden" name="wp-preview" id="wp-preview" value="" />
+			</div>
+			<?php
+		endif;
+
+		/**
+		 * Fires after the Save Draft (or Save as Pending) and Preview (or Preview Changes) buttons
+		 * in the Publish meta box.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param WP_Post $post WP_Post object for the current post.
+		 */
+		do_action( 'post_submitbox_minor_actions', $post );
+		?>
+		<div class="clear"></div>
+	</div>
+
+	<div id="misc-publishing-actions">
+		<div class="misc-pub-section misc-pub-post-status">
+			<?php _e( 'Status:' ); ?>
+			<span id="post-status-display">
+				<?php
+				switch ( $post->post_status ) {
+					case 'private':
+						_e( 'Privately Published' );
+						break;
+					case 'publish':
+						_e( 'Published' );
+						break;
+					case 'future':
+						_e( 'Scheduled' );
+						break;
+					case 'pending':
+						_e( 'Pending Review' );
+						break;
+					case 'draft':
+					case 'auto-draft':
+						_e( 'Draft' );
+						break;
+				}
+				?>
+			</span>
+
+			<?php
+			if ( 'publish' === $post->post_status || 'private' === $post->post_status || $can_publish ) {
+				$private_style = '';
+				if ( 'private' === $post->post_status ) {
+					$private_style = 'style="display:none"';
+				}
+				?>
+				<a href="#post_status" <?php echo $private_style; ?> class="edit-post-status hide-if-no-js" role="button"><span aria-hidden="true"><?php _e( 'Edit' ); ?></span> <span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Edit status' );
+					?>
+				</span></a>
+
+				<div id="post-status-select" class="hide-if-js">
+					<input type="hidden" name="hidden_post_status" id="hidden_post_status" value="<?php echo esc_attr( ( 'auto-draft' === $post->post_status ) ? 'draft' : $post->post_status ); ?>" />
+					<label for="post_status" class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Set status' );
+						?>
+					</label>
+					<select name="post_status" id="post_status">
+						<?php if ( 'publish' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'publish' ); ?> value='publish'><?php _e( 'Published' ); ?></option>
+						<?php elseif ( 'private' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'private' ); ?> value='publish'><?php _e( 'Privately Published' ); ?></option>
+						<?php elseif ( 'future' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'future' ); ?> value='future'><?php _e( 'Scheduled' ); ?></option>
+						<?php endif; ?>
+							<option<?php selected( $post->post_status, 'pending' ); ?> value='pending'><?php _e( 'Pending Review' ); ?></option>
+						<?php if ( 'auto-draft' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'auto-draft' ); ?> value='draft'><?php _e( 'Draft' ); ?></option>
+						<?php else : ?>
+							<option<?php selected( $post->post_status, 'draft' ); ?> value='draft'><?php _e( 'Draft' ); ?></option>
+						<?php endif; ?>
+					</select>
+					<a href="#post_status" class="save-post-status hide-if-no-js button"><?php _e( 'OK' ); ?></a>
+					<a href="#post_status" class="cancel-post-status hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
+				</div>
+				<?php
+			}
+			?>
+		</div>
+
+		<div class="misc-pub-section misc-pub-visibility" id="visibility">
+			<?php _e( 'Visibility:' ); ?>
+			<span id="post-visibility-display">
+				<?php
+				if ( 'private' === $post->post_status ) {
+					$post->post_password = '';
+					$visibility          = 'private';
+					$visibility_trans    = __( 'Private' );
+				} elseif ( ! empty( $post->post_password ) ) {
+					$visibility       = 'password';
+					$visibility_trans = __( 'Password protected' );
+				} elseif ( 'post' === $post_type && is_sticky( $post_id ) ) {
+					$visibility       = 'public';
+					$visibility_trans = __( 'Public, Sticky' );
+				} else {
+					$visibility       = 'public';
+					$visibility_trans = __( 'Public' );
+				}
+
+				echo esc_html( $visibility_trans );
+				?>
+			</span>
+
+			<?php if ( $can_publish ) { ?>
+				<a href="#visibility" class="edit-visibility hide-if-no-js" role="button"><span aria-hidden="true"><?php _e( 'Edit' ); ?></span> <span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Edit visibility' );
+					?>
+				</span></a>
+
+				<div id="post-visibility-select" class="hide-if-js">
+					<input type="hidden" name="hidden_post_password" id="hidden-post-password" value="<?php echo esc_attr( $post->post_password ); ?>" />
+					<?php if ( 'post' === $post_type ) : ?>
+						<input type="checkbox" style="display:none" name="hidden_post_sticky" id="hidden-post-sticky" value="sticky" <?php checked( is_sticky( $post_id ) ); ?> />
+					<?php endif; ?>
+
+					<input type="hidden" name="hidden_post_visibility" id="hidden-post-visibility" value="<?php echo esc_attr( $visibility ); ?>" />
+					<input type="radio" name="visibility" id="visibility-radio-public" value="public" <?php checked( $visibility, 'public' ); ?> /> <label for="visibility-radio-public" class="selectit"><?php _e( 'Public' ); ?></label><br />
+
+					<?php if ( 'post' === $post_type && current_user_can( 'edit_others_posts' ) ) : ?>
+						<span id="sticky-span"><input id="sticky" name="sticky" type="checkbox" value="sticky" <?php checked( is_sticky( $post_id ) ); ?> /> <label for="sticky" class="selectit"><?php _e( 'Stick this post to the front page' ); ?></label><br /></span>
+					<?php endif; ?>
+
+					<input type="radio" name="visibility" id="visibility-radio-password" value="password" <?php checked( $visibility, 'password' ); ?> /> <label for="visibility-radio-password" class="selectit"><?php _e( 'Password protected' ); ?></label><br />
+					<span id="password-span"><label for="post_password"><?php _e( 'Password:' ); ?></label> <input type="text" name="post_password" id="post_password" value="<?php echo esc_attr( $post->post_password ); ?>"  maxlength="255" /><br /></span>
+
+					<input type="radio" name="visibility" id="visibility-radio-private" value="private" <?php checked( $visibility, 'private' ); ?> /> <label for="visibility-radio-private" class="selectit"><?php _e( 'Private' ); ?></label><br />
+
+					<p>
+						<a href="#visibility" class="save-post-visibility hide-if-no-js button"><?php _e( 'OK' ); ?></a>
+						<a href="#visibility" class="cancel-post-visibility hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
+					</p>
+				</div>
+			<?php } ?>
+		</div>
+
+		<?php
+		/* translators: Publish box date string. 1: Date, 2: Time. See https://www.php.net/manual/datetime.format.php */
+		$date_string = __( '%1$s at %2$s' );
+		/* translators: Publish box date format, see https://www.php.net/manual/datetime.format.php */
+		$date_format = _x( 'M j, Y', 'publish box date format' );
+		/* translators: Publish box time format, see https://www.php.net/manual/datetime.format.php */
+		$time_format = _x( 'H:i', 'publish box time format' );
+
+		if ( 0 !== $post_id ) {
+			if ( 'future' === $post->post_status ) { // Scheduled for publishing at a future date.
+				/* translators: Post date information. %s: Date on which the post is currently scheduled to be published. */
+				$stamp = __( 'Scheduled for: %s' );
+			} elseif ( 'publish' === $post->post_status || 'private' === $post->post_status ) { // Already published.
+				/* translators: Post date information. %s: Date on which the post was published. */
+				$stamp = __( 'Published on: %s' );
+			} elseif ( '0000-00-00 00:00:00' === $post->post_date_gmt ) { // Draft, 1 or more saves, no date specified.
+				$stamp = __( 'Publish <b>immediately</b>' );
+			} elseif ( time() < strtotime( $post->post_date_gmt . ' +0000' ) ) { // Draft, 1 or more saves, future date specified.
+				/* translators: Post date information. %s: Date on which the post is to be published. */
+				$stamp = __( 'Schedule for: %s' );
+			} else { // Draft, 1 or more saves, date specified.
+				/* translators: Post date information. %s: Date on which the post is to be published. */
+				$stamp = __( 'Publish on: %s' );
+			}
+			$date = sprintf(
+				$date_string,
+				date_i18n( $date_format, strtotime( $post->post_date ) ),
+				date_i18n( $time_format, strtotime( $post->post_date ) )
+			);
+		} else { // Draft (no saves, and thus no date specified).
+			$stamp = __( 'Publish <b>immediately</b>' );
+			$date  = sprintf(
+				$date_string,
+				date_i18n( $date_format, strtotime( current_time( 'mysql' ) ) ),
+				date_i18n( $time_format, strtotime( current_time( 'mysql' ) ) )
+			);
+		}
+
+		if ( ! empty( $args['args']['revisions_count'] ) ) :
+			?>
+			<div class="misc-pub-section misc-pub-revisions">
+				<?php
+				/* translators: Post revisions heading. %s: The number of available revisions. */
+				printf( __( 'Revisions: %s' ), '<b>' . number_format_i18n( $args['args']['revisions_count'] ) . '</b>' );
+				?>
+				<a class="hide-if-no-js" href="<?php echo esc_url( get_edit_post_link( $args['args']['revision_id'] ) ); ?>"><span aria-hidden="true"><?php _ex( 'Browse', 'revisions' ); ?></span> <span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Browse revisions' );
+					?>
+				</span></a>
+			</div>
+			<?php
+		endif;
+
+		if ( $can_publish ) : // Contributors don't get to choose the date of publish.
+			?>
+			<div class="misc-pub-section curtime misc-pub-curtime">
+				<span id="timestamp">
+					<?php printf( $stamp, '<b>' . $date . '</b>' ); ?>
+				</span>
+				<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
+					<span aria-hidden="true"><?php _e( 'Edit' ); ?></span>
+					<span class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Edit date and time' );
+						?>
+					</span>
+				</a>
+				<fieldset id="timestampdiv" class="hide-if-js">
+					<legend class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Date and time' );
+						?>
+					</legend>
+					<?php touch_time( ( 'edit' === $action ), 1 ); ?>
+				</fieldset>
+			</div>
+			<?php
+		endif;
+
+		if ( 'draft' === $post->post_status && get_post_meta( $post_id, '_customize_changeset_uuid', true ) ) :
+			$message = sprintf(
+				/* translators: %s: URL to the Customizer. */
+				__( 'This draft comes from your <a href="%s">unpublished customization changes</a>. You can edit, but there is no need to publish now. It will be published automatically with those changes.' ),
+				esc_url(
+					add_query_arg(
+						'changeset_uuid',
+						rawurlencode( get_post_meta( $post_id, '_customize_changeset_uuid', true ) ),
+						admin_url( 'customize.php' )
+					)
+				)
+			);
+			wp_admin_notice(
+				$message,
+				array(
+					'type'               => 'info',
+					'additional_classes' => array( 'notice-alt', 'inline' ),
+				)
+			);
+		endif;
+
+		/**
+		 * Fires after the post time/date setting in the Publish meta box.
+		 *
+		 * @since 2.9.0
+		 * @since 4.4.0 Added the `$post` parameter.
+		 *
+		 * @param WP_Post $post WP_Post object for the current post.
+		 */
+		do_action( 'post_submitbox_misc_actions', $post );
+		?>
+	</div>
+	<div class="clear"></div>
+</div>
+
+<div id="major-publishing-actions">
+	<?php
+	/**
+	 * Fires at the beginning of the publishing actions section of the Publish meta box.
+	 *
+	 * @since 2.7.0
+	 * @since 4.9.0 Added the `$post` parameter.
+	 *
+	 * @param WP_Post|null $post WP_Post object for the current post on Edit Post screen,
+	 *                           null on Edit Link screen.
+	 */
+	do_action( 'post_submitbox_start', $post );
+	?>
+	<div id="delete-action">
+		<?php
+		if ( current_user_can( 'delete_post', $post_id ) ) {
+			if ( ! EMPTY_TRASH_DAYS ) {
+				$delete_text = __( 'Delete permanently' );
+			} else {
+				$delete_text = __( 'Move to Trash' );
+			}
+			?>
+			<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post_id ); ?>"><?php echo $delete_text; ?></a>
+			<?php
+		}
+		?>
+	</div>
+
+	<div id="publishing-action">
+		<span class="spinner"></span>
+		<?php
+		if ( ! in_array( $post->post_status, array( 'publish', 'future', 'private' ), true ) || 0 === $post_id ) {
+			if ( $can_publish ) :
+				if ( ! empty( $post->post_date_gmt ) && time() < strtotime( $post->post_date_gmt . ' +0000' ) ) :
+					?>
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php echo esc_attr_x( 'Schedule', 'post action/button label' ); ?>" />
+					<?php submit_button( _x( 'Schedule', 'post action/button label' ), 'primary large', 'publish', false ); ?>
+					<?php
+				else :
+					?>
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Publish' ); ?>" />
+					<?php submit_button( __( 'Publish' ), 'primary large', 'publish', false ); ?>
+					<?php
+				endif;
+			else :
+				?>
+				<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Submit for Review' ); ?>" />
+				<?php submit_button( __( 'Submit for Review' ), 'primary large', 'publish', false ); ?>
+				<?php
+			endif;
+		} else {
+			?>
+			<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Update' ); ?>" />
+			<?php submit_button( __( 'Update' ), 'primary large', 'save', false, array( 'id' => 'publish' ) ); ?>
+			<?php
+		}
+		?>
+	</div>
+	<div class="clear"></div>
+</div>
+
+</div>
+	<?php
+}
+
+/**
+ * Displays attachment submit form fields.
+ *
+ * @since 3.5.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function attachment_submit_meta_box( $post ) {
+	?>
+<div class="submitbox" id="submitpost">
+
+<div id="minor-publishing">
+
+	<?php // Hidden submit button early on so that the browser chooses the right button when form is submitted with Return key. ?>
+<div style="display:none;">
+	<?php submit_button( __( 'Save' ), '', 'save' ); ?>
+</div>
+
+
+<div id="misc-publishing-actions">
+	<div class="misc-pub-section curtime misc-pub-curtime">
+		<span id="timestamp">
+			<?php
+			$uploaded_on = sprintf(
+				/* translators: Publish box date string. 1: Date, 2: Time. */
+				__( '%1$s at %2$s' ),
+				/* translators: Publish box date format, see https://www.php.net/manual/datetime.format.php */
+				date_i18n( _x( 'M j, Y', 'publish box date format' ), strtotime( $post->post_date ) ),
+				/* translators: Publish box time format, see https://www.php.net/manual/datetime.format.php */
+				date_i18n( _x( 'H:i', 'publish box time format' ), strtotime( $post->post_date ) )
+			);
+			/* translators: Attachment information. %s: Date the attachment was uploaded. */
+			printf( __( 'Uploaded on: %s' ), '<b>' . $uploaded_on . '</b>' );
+			?>
+		</span>
+	</div><!-- .misc-pub-section -->
+
+	<?php
+	/**
+	 * Fires after the 'Uploaded on' section of the Save meta box
+	 * in the attachment editing screen.
+	 *
+	 * @since 3.5.0
+	 * @since 4.9.0 Added the `$post` parameter.
+	 *
+	 * @param WP_Post $post WP_Post object for the current attachment.
+	 */
+	do_action( 'attachment_submitbox_misc_actions', $post );
+	?>
+</div><!-- #misc-publishing-actions -->
+<div class="clear"></div>
+</div><!-- #minor-publishing -->
+
+<div id="major-publishing-actions">
+	<div id="delete-action">
+	<?php
+	if ( current_user_can( 'delete_post', $post->ID ) ) {
+		if ( EMPTY_TRASH_DAYS && MEDIA_TRASH ) {
+			printf(
+				'<a class="submitdelete deletion" href="%1$s">%2$s</a>',
+				get_delete_post_link( $post->ID ),
+				__( 'Move to Trash' )
+			);
+		} else {
+			$show_confirmation = ! MEDIA_TRASH ? " onclick='return showNotice.warn();'" : '';
+
+			printf(
+				'<a class="submitdelete deletion"%1$s href="%2$s">%3$s</a>',
+				$show_confirmation,
+				get_delete_post_link( $post->ID, '', true ),
+				__( 'Delete permanently' )
+			);
+		}
+	}
+	?>
+	</div>
+
+	<div id="publishing-action">
+		<span class="spinner"></span>
+		<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Update' ); ?>" />
+		<input name="save" type="submit" class="button button-primary button-large" id="publish" value="<?php esc_attr_e( 'Update' ); ?>" />
+	</div>
+	<div class="clear"></div>
+</div><!-- #major-publishing-actions -->
+
+</div>
+
+	<?php
+}
+
+/**
+ * Displays post format form elements.
+ *
+ * @since 3.1.0
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box {
+ *     Post formats meta box arguments.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args     Extra meta box arguments.
+ * }
+ */
+function post_format_meta_box( $post, $box ) {
+	if ( current_theme_supports( 'post-formats' ) && post_type_supports( $post->post_type, 'post-formats' ) ) :
+		$post_formats = get_theme_support( 'post-formats' );
+
+		if ( is_array( $post_formats[0] ) ) :
+			$post_format = get_post_format( $post->ID );
+			if ( ! $post_format ) {
+				$post_format = '0';
+			}
+			// Add in the current one if it isn't there yet, in case the active theme doesn't support it.
+			if ( $post_format && ! in_array( $post_format, $post_formats[0], true ) ) {
+				$post_formats[0][] = $post_format;
+			}
+			?>
+		<div id="post-formats-select">
+		<fieldset>
+			<legend class="screen-reader-text">
+				<?php
+				/* translators: Hidden accessibility text. */
+				_e( 'Post Formats' );
+				?>
+			</legend>
+			<input type="radio" name="post_format" class="post-format" id="post-format-0" value="0" <?php checked( $post_format, '0' ); ?> /> <label for="post-format-0" class="post-format-icon post-format-standard"><?php echo get_post_format_string( 'standard' ); ?></label>
+			<?php foreach ( $post_formats[0] as $format ) : ?>
+			<br /><input type="radio" name="post_format" class="post-format" id="post-format-<?php echo esc_attr( $format ); ?>" value="<?php echo esc_attr( $format ); ?>" <?php checked( $post_format, $format ); ?> /> <label for="post-format-<?php echo esc_attr( $format ); ?>" class="post-format-icon post-format-<?php echo esc_attr( $format ); ?>"><?php echo esc_html( get_post_format_string( $format ) ); ?></label>
+			<?php endforeach; ?>
+		</fieldset>
+	</div>
+			<?php
+	endif;
+endif;
+}
+
+/**
+ * Displays post tags form fields.
+ *
+ * @since 2.6.0
+ *
+ * @todo Create taxonomy-agnostic wrapper for this.
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box {
+ *     Tags meta box arguments.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args {
+ *         Extra meta box arguments.
+ *
+ *         @type string $taxonomy Taxonomy. Default 'post_tag'.
+ *     }
+ * }
+ */
+function post_tags_meta_box( $post, $box ) {
+	$defaults = array( 'taxonomy' => 'post_tag' );
+	if ( ! isset( $box['args'] ) || ! is_array( $box['args'] ) ) {
+		$args = array();
+	} else {
+		$args = $box['args'];
+	}
+	$parsed_args           = wp_parse_args( $args, $defaults );
+	$tax_name              = esc_attr( $parsed_args['taxonomy'] );
+	$taxonomy              = get_taxonomy( $parsed_args['taxonomy'] );
+	$user_can_assign_terms = current_user_can( $taxonomy->cap->assign_terms );
+	$comma                 = _x( ',', 'tag delimiter' );
+	$terms_to_edit         = get_terms_to_edit( $post->ID, $tax_name );
+	if ( ! is_string( $terms_to_edit ) ) {
+		$terms_to_edit = '';
+	}
+	?>
+<div class="tagsdiv" id="<?php echo $tax_name; ?>">
+	<div class="jaxtag">
+	<div class="nojs-tags hide-if-js">
+		<label for="tax-input-<?php echo $tax_name; ?>"><?php echo $taxonomy->labels->add_or_remove_items; ?></label>
+		<p><textarea name="<?php echo "tax_input[$tax_name]"; ?>" rows="3" cols="20" class="the-tags" id="tax-input-<?php echo $tax_name; ?>" <?php disabled( ! $user_can_assign_terms ); ?> aria-describedby="new-tag-<?php echo $tax_name; ?>-desc"><?php echo str_replace( ',', $comma . ' ', $terms_to_edit ); // textarea_escaped by esc_attr() ?></textarea></p>
+	</div>
+	<?php if ( $user_can_assign_terms ) : ?>
+	<div class="ajaxtag hide-if-no-js">
+		<label class="screen-reader-text" for="new-tag-<?php echo $tax_name; ?>"><?php echo $taxonomy->labels->add_new_item; ?></label>
+		<input data-wp-taxonomy="<?php echo $tax_name; ?>" type="text" id="new-tag-<?php echo $tax_name; ?>" name="newtag[<?php echo $tax_name; ?>]" class="newtag form-input-tip" size="16" autocomplete="off" aria-describedby="new-tag-<?php echo $tax_name; ?>-desc" value="" />
+		<input type="button" class="button tagadd" value="<?php esc_attr_e( 'Add' ); ?>" />
+	</div>
+	<p class="howto" id="new-tag-<?php echo $tax_name; ?>-desc"><?php echo $taxonomy->labels->separate_items_with_commas; ?></p>
+	<?php elseif ( empty( $terms_to_edit ) ) : ?>
+		<p><?php echo $taxonomy->labels->no_terms; ?></p>
+	<?php endif; ?>
+	</div>
+	<ul class="tagchecklist" role="list"></ul>
+</div>
+	<?php if ( $user_can_assign_terms ) : ?>
+<p class="hide-if-no-js"><button type="button" class="button-link tagcloud-link" id="link-<?php echo $tax_name; ?>" aria-expanded="false"><?php echo $taxonomy->labels->choose_from_most_used; ?></button></p>
+<?php endif; ?>
+	<?php
+}
+
+/**
+ * Displays post categories form fields.
+ *
+ * @since 2.6.0
+ *
+ * @todo Create taxonomy-agnostic wrapper for this.
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box {
+ *     Categories meta box arguments.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args {
+ *         Extra meta box arguments.
+ *
+ *         @type string $taxonomy Taxonomy. Default 'category'.
+ *     }
+ * }
+ */
+function post_categories_meta_box( $post, $box ) {
+	$defaults = array( 'taxonomy' => 'category' );
+	if ( ! isset( $box['args'] ) || ! is_array( $box['args'] ) ) {
+		$args = array();
+	} else {
+		$args = $box['args'];
+	}
+	$parsed_args = wp_parse_args( $args, $defaults );
+	$tax_name    = esc_attr( $parsed_args['taxonomy'] );
+	$taxonomy    = get_taxonomy( $parsed_args['taxonomy'] );
+	?>
+	<div id="taxonomy-<?php echo $tax_name; ?>" class="categorydiv">
+		<ul id="<?php echo $tax_name; ?>-tabs" class="category-tabs">
+			<li class="tabs"><a href="#<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
+			<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop"><?php echo esc_html( $taxonomy->labels->most_used ); ?></a></li>
+		</ul>
+
+		<div id="<?php echo $tax_name; ?>-pop" class="tabs-panel" style="display: none;">
+			<ul id="<?php echo $tax_name; ?>checklist-pop" class="categorychecklist form-no-clear" >
+				<?php $popular_ids = wp_popular_terms_checklist( $tax_name ); ?>
+			</ul>
+		</div>
+
+		<div id="<?php echo $tax_name; ?>-all" class="tabs-panel">
+			<?php
+			$name = ( 'category' === $tax_name ) ? 'post_category' : 'tax_input[' . $tax_name . ']';
+			// Allows for an empty term set to be sent. 0 is an invalid term ID and will be ignored by empty() checks.
+			echo "<input type='hidden' name='{$name}[]' value='0' />";
+			?>
+			<ul id="<?php echo $tax_name; ?>checklist" data-wp-lists="list:<?php echo $tax_name; ?>" class="categorychecklist form-no-clear">
+				<?php
+				wp_terms_checklist(
+					$post->ID,
+					array(
+						'taxonomy'     => $tax_name,
+						'popular_cats' => $popular_ids,
+					)
+				);
+				?>
+			</ul>
+		</div>
+	<?php if ( current_user_can( $taxonomy->cap->edit_terms ) ) : ?>
+			<div id="<?php echo $tax_name; ?>-adder" class="wp-hidden-children">
+				<a id="<?php echo $tax_name; ?>-add-toggle" href="#<?php echo $tax_name; ?>-add" class="hide-if-no-js taxonomy-add-new">
+					<?php
+						/* translators: %s: Add New taxonomy label. */
+						printf( __( '+ %s' ), $taxonomy->labels->add_new_item );
+					?>
+				</a>
+				<p id="<?php echo $tax_name; ?>-add" class="category-add wp-hidden-child">
+					<label class="screen-reader-text" for="new<?php echo $tax_name; ?>"><?php echo $taxonomy->labels->add_new_item; ?></label>
+					<input type="text" name="new<?php echo $tax_name; ?>" id="new<?php echo $tax_name; ?>" class="form-required form-input-tip" value="<?php echo esc_attr( $taxonomy->labels->new_item_name ); ?>" aria-required="true" />
+					<label class="screen-reader-text" for="new<?php echo $tax_name; ?>_parent">
+						<?php echo $taxonomy->labels->parent_item_colon; ?>
+					</label>
+					<?php
+					$parent_dropdown_args = array(
+						'taxonomy'         => $tax_name,
+						'hide_empty'       => 0,
+						'name'             => 'new' . $tax_name . '_parent',
+						'orderby'          => 'name',
+						'hierarchical'     => 1,
+						'show_option_none' => '&mdash; ' . $taxonomy->labels->parent_item . ' &mdash;',
+					);
+
+					/**
+					 * Filters the arguments for the taxonomy parent dropdown on the Post Edit page.
+					 *
+					 * @since 4.4.0
+					 *
+					 * @param array $parent_dropdown_args {
+					 *     Optional. Array of arguments to generate parent dropdown.
+					 *
+					 *     @type string   $taxonomy         Name of the taxonomy to retrieve.
+					 *     @type bool     $hide_if_empty    True to skip generating markup if no
+					 *                                      categories are found. Default 0.
+					 *     @type string   $name             Value for the 'name' attribute
+					 *                                      of the select element.
+					 *                                      Default "new{$tax_name}_parent".
+					 *     @type string   $orderby          Which column to use for ordering
+					 *                                      terms. Default 'name'.
+					 *     @type bool|int $hierarchical     Whether to traverse the taxonomy
+					 *                                      hierarchy. Default 1.
+					 *     @type string   $show_option_none Text to display for the "none" option.
+					 *                                      Default "&mdash; {$parent} &mdash;",
+					 *                                      where `$parent` is 'parent_item'
+					 *                                      taxonomy label.
+					 * }
+					 */
+					$parent_dropdown_args = apply_filters( 'post_edit_category_parent_dropdown_args', $parent_dropdown_args );
+
+					wp_dropdown_categories( $parent_dropdown_args );
+					?>
+					<input type="button" id="<?php echo $tax_name; ?>-add-submit" data-wp-lists="add:<?php echo $tax_name; ?>checklist:<?php echo $tax_name; ?>-add" class="button category-add-submit" value="<?php echo esc_attr( $taxonomy->labels->add_new_item ); ?>" />
+					<?php wp_nonce_field( 'add-' . $tax_name, '_ajax_nonce-add-' . $tax_name, false ); ?>
+					<span id="<?php echo $tax_name; ?>-ajax-response"></span>
+				</p>
+			</div>
+		<?php endif; ?>
+	</div>
+	<?php
+}
+
+/**
+ * Displays post excerpt form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_excerpt_meta_box( $post ) {
+	?>
+<label class="screen-reader-text" for="excerpt">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Excerpt' );
+	?>
+</label><textarea rows="1" cols="40" name="excerpt" id="excerpt"><?php echo $post->post_excerpt; // textarea_escaped ?></textarea>
+<p>
+	<?php
+	printf(
+		/* translators: %s: Documentation URL. */
+		__( 'Excerpts are optional hand-crafted summaries of your content that can be used in your theme. <a href="%s">Learn more about manual excerpts</a>.' ),
+		__( 'https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/' )
+	);
+	?>
+</p>
+	<?php
+}
+
+/**
+ * Displays trackback links form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_trackback_meta_box( $post ) {
+	$form_trackback = '<input type="text" name="trackback_url" id="trackback_url" class="code" value="' .
+		esc_attr( str_replace( "\n", ' ', $post->to_ping ) ) . '" aria-describedby="trackback-url-desc" />';
+
+	if ( '' !== $post->pinged ) {
+		$pings          = '<p>' . __( 'Already pinged:' ) . '</p><ul>';
+		$already_pinged = explode( "\n", trim( $post->pinged ) );
+		foreach ( $already_pinged as $pinged_url ) {
+			$pings .= "\n\t<li>" . esc_html( $pinged_url ) . '</li>';
+		}
+		$pings .= '</ul>';
+	}
+
+	?>
+<p>
+	<label for="trackback_url"><?php _e( 'Send trackbacks to:' ); ?></label>
+	<?php echo $form_trackback; ?>
+</p>
+<p id="trackback-url-desc" class="howto"><?php _e( 'Separate multiple URLs with spaces' ); ?></p>
+<p>
+	<?php
+	printf(
+		/* translators: %s: Documentation URL. */
+		__( 'Trackbacks are a way to notify legacy blog systems that you&#8217;ve linked to them. If you link other WordPress sites, they&#8217;ll be notified automatically using <a href="%s">pingbacks</a>, no other action necessary.' ),
+		__( 'https://wordpress.org/documentation/article/introduction-to-blogging/#comments' )
+	);
+	?>
+</p>
+	<?php
+	if ( ! empty( $pings ) ) {
+		echo $pings;
+	}
+}
+
+/**
+ * Displays custom fields form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_custom_meta_box( $post ) {
+	?>
+<div id="postcustomstuff">
+<div id="ajax-response"></div>
+	<?php
+	$metadata = has_meta( $post->ID );
+	foreach ( $metadata as $key => $value ) {
+		if ( is_protected_meta( $metadata[ $key ]['meta_key'], 'post' ) || ! current_user_can( 'edit_post_meta', $post->ID, $metadata[ $key ]['meta_key'] ) ) {
+			unset( $metadata[ $key ] );
+		}
+	}
+	list_meta( $metadata );
+	meta_form( $post );
+	?>
+</div>
+<p>
+	<?php
+	printf(
+		/* translators: %s: Documentation URL. */
+		__( 'Custom fields can be used to add extra metadata to a post that you can <a href="%s">use in your theme</a>.' ),
+		__( 'https://wordpress.org/documentation/article/assign-custom-fields/' )
+	);
+	?>
+</p>
+	<?php
+}
+
+/**
+ * Displays comments status form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_comment_status_meta_box( $post ) {
+	?>
+<input name="advanced_view" type="hidden" value="1" />
+<p class="meta-options">
+	<label for="comment_status" class="selectit"><input name="comment_status" type="checkbox" id="comment_status" value="open" <?php checked( $post->comment_status, 'open' ); ?> /> <?php _e( 'Allow comments' ); ?></label><br />
+	<label for="ping_status" class="selectit"><input name="ping_status" type="checkbox" id="ping_status" value="open" <?php checked( $post->ping_status, 'open' ); ?> />
+		<?php
+		printf(
+			/* translators: %s: Documentation URL. */
+			__( 'Allow <a href="%s">trackbacks and pingbacks</a>' ),
+			__( 'https://wordpress.org/documentation/article/introduction-to-blogging/#managing-comments' )
+		);
+		?>
+	</label>
+	<?php
+	/**
+	 * Fires at the end of the Discussion meta box on the post editing screen.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Post $post WP_Post object for the current post.
+	 */
+	do_action( 'post_comment_status_meta_box-options', $post ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	?>
+</p>
+	<?php
+}
+
+/**
+ * Displays comments for post table header
+ *
+ * @since 3.0.0
+ *
+ * @param array $result Table header rows.
+ * @return array
+ */
+function post_comment_meta_box_thead( $result ) {
+	unset( $result['cb'], $result['response'] );
+	return $result;
+}
+
+/**
+ * Displays comments for post.
+ *
+ * @since 2.8.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_comment_meta_box( $post ) {
+	wp_nonce_field( 'get-comments', 'add_comment_nonce', false );
+	?>
+	<p class="hide-if-no-js" id="add-new-comment"><button type="button" class="button" onclick="window.commentReply && commentReply.addcomment(<?php echo $post->ID; ?>);"><?php _e( 'Add Comment' ); ?></button></p>
+	<?php
+
+	$total         = get_comments(
+		array(
+			'post_id' => $post->ID,
+			'count'   => true,
+			'orderby' => 'none',
+		)
+	);
+	$wp_list_table = _get_list_table( 'WP_Post_Comments_List_Table' );
+	$wp_list_table->display( true );
+
+	if ( 1 > $total ) {
+		echo '<p id="no-comments">' . __( 'No comments yet.' ) . '</p>';
+	} else {
+		$hidden = get_hidden_meta_boxes( get_current_screen() );
+		if ( ! in_array( 'commentsdiv', $hidden, true ) ) {
+			?>
+			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
+			<?php
+		}
+
+		?>
+		<p class="hide-if-no-js" id="show-comments"><a href="#commentstatusdiv" onclick="commentsBox.load(<?php echo $total; ?>);return false;"><?php _e( 'Show comments' ); ?></a> <span class="spinner"></span></p>
+		<?php
+	}
+
+	wp_comment_trashnotice();
+}
+
+/**
+ * Displays slug form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_slug_meta_box( $post ) {
+	/** This filter is documented in wp-admin/edit-tag-form.php */
+	$editable_slug = apply_filters( 'editable_slug', $post->post_name, $post );
+	?>
+<label class="screen-reader-text" for="post_name">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Slug' );
+	?>
+</label><input name="post_name" type="text" class="large-text" id="post_name" value="<?php echo esc_attr( $editable_slug ); ?>" />
+	<?php
+}
+
+/**
+ * Displays form field with list of authors.
+ *
+ * @since 2.6.0
+ *
+ * @global int $user_ID
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_author_meta_box( $post ) {
+	global $user_ID;
+
+	$post_type_object = get_post_type_object( $post->post_type );
+	?>
+<label class="screen-reader-text" for="post_author_override">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Author' );
+	?>
+</label>
+	<?php
+	wp_dropdown_users(
+		array(
+			'capability'       => array( $post_type_object->cap->edit_posts ),
+			'name'             => 'post_author_override',
+			'selected'         => empty( $post->ID ) ? $user_ID : $post->post_author,
+			'include_selected' => true,
+			'show'             => 'display_name_with_login',
+		)
+	);
+}
+
+/**
+ * Displays list of revisions.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_revisions_meta_box( $post ) {
+	wp_list_post_revisions( $post );
+}
+
+//
+// Page-related Meta Boxes.
+//
+
+/**
+ * Displays page attributes form fields.
+ *
+ * @since 2.7.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function page_attributes_meta_box( $post ) {
+	if ( is_post_type_hierarchical( $post->post_type ) ) :
+		$dropdown_args = array(
+			'post_type'        => $post->post_type,
+			'exclude_tree'     => $post->ID,
+			'selected'         => $post->post_parent,
+			'name'             => 'parent_id',
+			'show_option_none' => __( '(no parent)' ),
+			'sort_column'      => 'menu_order, post_title',
+			'echo'             => 0,
+		);
+
+		/**
+		 * Filters the arguments used to generate a Pages drop-down element.
+		 *
+		 * @since 3.3.0
+		 *
+		 * @see wp_dropdown_pages()
+		 *
+		 * @param array   $dropdown_args Array of arguments used to generate the pages drop-down.
+		 * @param WP_Post $post          The current post.
+		 */
+		$dropdown_args = apply_filters( 'page_attributes_dropdown_pages_args', $dropdown_args, $post );
+		$pages         = wp_dropdown_pages( $dropdown_args );
+		if ( ! empty( $pages ) ) :
+			?>
+<p class="post-attributes-label-wrapper parent-id-label-wrapper"><label class="post-attributes-label" for="parent_id"><?php _e( 'Parent' ); ?></label></p>
+			<?php echo $pages; ?>
+			<?php
+		endif; // End empty pages check.
+	endif;  // End hierarchical check.
+
+	if ( count( get_page_templates( $post ) ) > 0 && (int) get_option( 'page_for_posts' ) !== $post->ID ) :
+		$template = ! empty( $post->page_template ) ? $post->page_template : false;
+		?>
+<p class="post-attributes-label-wrapper page-template-label-wrapper"><label class="post-attributes-label" for="page_template"><?php _e( 'Template' ); ?></label>
+		<?php
+		/**
+		 * Fires immediately after the label inside the 'Template' section
+		 * of the 'Page Attributes' meta box.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param string|false $template The template used for the current post.
+		 * @param WP_Post      $post     The current post.
+		 */
+		do_action( 'page_attributes_meta_box_template', $template, $post );
+		?>
+</p>
+<select name="page_template" id="page_template">
+		<?php
+		/**
+		 * Filters the title of the default page template displayed in the drop-down.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param string $label   The display value for the default page template title.
+		 * @param string $context Where the option label is displayed. Possible values
+		 *                        include 'meta-box' or 'quick-edit'.
+		 */
+		$default_title = apply_filters( 'default_page_template_title', __( 'Default template' ), 'meta-box' );
+		?>
+<option value="default"><?php echo esc_html( $default_title ); ?></option>
+		<?php page_template_dropdown( $template, $post->post_type ); ?>
+</select>
+<?php endif; ?>
+	<?php if ( post_type_supports( $post->post_type, 'page-attributes' ) ) : ?>
+<p class="post-attributes-label-wrapper menu-order-label-wrapper"><label class="post-attributes-label" for="menu_order"><?php _e( 'Order' ); ?></label></p>
+<input name="menu_order" type="text" size="4" id="menu_order" value="<?php echo esc_attr( $post->menu_order ); ?>" />
+		<?php
+		/**
+		 * Fires before the help hint text in the 'Page Attributes' meta box.
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param WP_Post $post The current post.
+		 */
+		do_action( 'page_attributes_misc_attributes', $post );
+		?>
+		<?php if ( 'page' === $post->post_type && get_current_screen()->get_help_tabs() ) : ?>
+<p class="post-attributes-help-text"><?php _e( 'Need help? Use the Help tab above the screen title.' ); ?></p>
+			<?php
+	endif;
+	endif;
+}
+
+//
+// Link-related Meta Boxes.
+//
+
+/**
+ * Displays link create form fields.
+ *
+ * @since 2.7.0
+ *
+ * @param object $link Current link object.
+ */
+function link_submit_meta_box( $link ) {
+	?>
+<div class="submitbox" id="submitlink">
+
+<div id="minor-publishing">
+
+	<?php // Hidden submit button early on so that the browser chooses the right button when form is submitted with Return key. ?>
+<div style="display:none;">
+	<?php submit_button( __( 'Save' ), '', 'save', false ); ?>
+</div>
+
+<div id="minor-publishing-actions">
+<div id="preview-action">
+	<?php if ( ! empty( $link->link_id ) ) { ?>
+	<a class="preview button" href="<?php echo $link->link_url; ?>" target="_blank"><?php _e( 'Visit Link' ); ?></a>
+<?php } ?>
+</div>
+<div class="clear"></div>
+</div>
+
+<div id="misc-publishing-actions">
+<div class="misc-pub-section misc-pub-private">
+	<label for="link_private" class="selectit"><input id="link_private" name="link_visible" type="checkbox" value="N" <?php checked( $link->link_visible, 'N' ); ?> /> <?php _e( 'Keep this link private' ); ?></label>
+</div>
+</div>
+
+</div>
+
+<div id="major-publishing-actions">
+	<?php
+	/** This action is documented in wp-admin/includes/meta-boxes.php */
+	do_action( 'post_submitbox_start', null );
+	?>
+<div id="delete-action">
+	<?php
+	if ( ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] && current_user_can( 'manage_links' ) ) {
+		printf(
+			'<a class="submitdelete deletion" href="%s" onclick="return confirm( \'%s\' );">%s</a>',
+			wp_nonce_url( "link.php?action=delete&amp;link_id=$link->link_id", 'delete-bookmark_' . $link->link_id ),
+			/* translators: %s: Link name. */
+			esc_js( sprintf( __( "You are about to delete this link '%s'\n  'Cancel' to stop, 'OK' to delete." ), $link->link_name ) ),
+			__( 'Delete' )
+		);
+	}
+	?>
+</div>
+
+<div id="publishing-action">
+	<?php if ( ! empty( $link->link_id ) ) { ?>
+	<input name="save" type="submit" class="button button-primary button-large" id="publish" value="<?php esc_attr_e( 'Update Link' ); ?>" />
+<?php } else { ?>
+	<input name="save" type="submit" class="button button-primary button-large" id="publish" value="<?php esc_attr_e( 'Add Link' ); ?>" />
+<?php } ?>
+</div>
+<div class="clear"></div>
+</div>
+	<?php
+	/**
+	 * Fires at the end of the Publish box in the Link editing screen.
+	 *
+	 * @since 2.5.0
+	 */
+	do_action( 'submitlink_box' );
+	?>
+<div class="clear"></div>
+</div>
+	<?php
+}
+
+/**
+ * Displays link categories form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_categories_meta_box( $link ) {
+	?>
+<div id="taxonomy-linkcategory" class="categorydiv">
+	<ul id="category-tabs" class="category-tabs">
+		<li class="tabs"><a href="#categories-all"><?php _e( 'All categories' ); ?></a></li>
+		<li class="hide-if-no-js"><a href="#categories-pop"><?php _ex( 'Most Used', 'categories' ); ?></a></li>
+	</ul>
+
+	<div id="categories-all" class="tabs-panel">
+		<ul id="categorychecklist" data-wp-lists="list:category" class="categorychecklist form-no-clear">
+			<?php
+			if ( isset( $link->link_id ) ) {
+				wp_link_category_checklist( $link->link_id );
+			} else {
+				wp_link_category_checklist();
+			}
+			?>
+		</ul>
+	</div>
+
+	<div id="categories-pop" class="tabs-panel" style="display: none;">
+		<ul id="categorychecklist-pop" class="categorychecklist form-no-clear">
+			<?php wp_popular_terms_checklist( 'link_category' ); ?>
+		</ul>
+	</div>
+
+	<div id="category-adder" class="wp-hidden-children">
+		<a id="category-add-toggle" href="#category-add" class="taxonomy-add-new"><?php _e( '+ Add New Category' ); ?></a>
+		<p id="link-category-add" class="wp-hidden-child">
+			<label class="screen-reader-text" for="newcat">
+				<?php
+				/* translators: Hidden accessibility text. */
+				_e( '+ Add New Category' );
+				?>
+			</label>
+			<input type="text" name="newcat" id="newcat" class="form-required form-input-tip" value="<?php esc_attr_e( 'New category name' ); ?>" aria-required="true" />
+			<input type="button" id="link-category-add-submit" data-wp-lists="add:categorychecklist:link-category-add" class="button" value="<?php esc_attr_e( 'Add' ); ?>" />
+			<?php wp_nonce_field( 'add-link-category', '_ajax_nonce', false ); ?>
+			<span id="category-ajax-response"></span>
+		</p>
+	</div>
+</div>
+	<?php
+}
+
+/**
+ * Displays form fields for changing link target.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_target_meta_box( $link ) {
+
+	?>
+<fieldset><legend class="screen-reader-text"><span>
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Target' );
+	?>
+</span></legend>
+<p><label for="link_target_blank" class="selectit">
+<input id="link_target_blank" type="radio" name="link_target" value="_blank" <?php echo ( isset( $link->link_target ) && ( '_blank' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
+	<?php _e( '<code>_blank</code> &mdash; new window or tab.' ); ?></label></p>
+<p><label for="link_target_top" class="selectit">
+<input id="link_target_top" type="radio" name="link_target" value="_top" <?php echo ( isset( $link->link_target ) && ( '_top' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
+	<?php _e( '<code>_top</code> &mdash; current window or tab, with no frames.' ); ?></label></p>
+<p><label for="link_target_none" class="selectit">
+<input id="link_target_none" type="radio" name="link_target" value="" <?php echo ( isset( $link->link_target ) && ( '' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
+	<?php _e( '<code>_none</code> &mdash; same window or tab.' ); ?></label></p>
+</fieldset>
+<p><?php _e( 'Choose the target frame for your link.' ); ?></p>
+	<?php
+}
+
+/**
+ * Displays 'checked' checkboxes attribute for XFN microformat options.
+ *
+ * @since 1.0.1
+ *
+ * @global object $link Current link object.
+ *
+ * @param string $xfn_relationship XFN relationship category. Possible values are:
+ *                                 'friendship', 'physical', 'professional',
+ *                                 'geographical', 'family', 'romantic', 'identity'.
+ * @param string $xfn_value        Optional. The XFN value to mark as checked
+ *                                 if it matches the current link's relationship.
+ *                                 Default empty string.
+ * @param mixed  $deprecated       Deprecated. Not used.
+ */
+function xfn_check( $xfn_relationship, $xfn_value = '', $deprecated = '' ) {
+	global $link;
+
+	if ( ! empty( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '2.5.0' ); // Never implemented.
+	}
+
+	$link_rel  = isset( $link->link_rel ) ? $link->link_rel : ''; // In PHP 5.3: $link_rel = $link->link_rel ?: '';
+	$link_rels = preg_split( '/\s+/', $link_rel );
+
+	// Mark the specified value as checked if it matches the current link's relationship.
+	if ( '' !== $xfn_value && in_array( $xfn_value, $link_rels, true ) ) {
+		echo ' checked="checked"';
+	}
+
+	if ( '' === $xfn_value ) {
+		// Mark the 'none' value as checked if the current link does not match the specified relationship.
+		if ( 'family' === $xfn_relationship
+			&& ! array_intersect( $link_rels, array( 'child', 'parent', 'sibling', 'spouse', 'kin' ) )
+		) {
+			echo ' checked="checked"';
+		}
+
+		if ( 'friendship' === $xfn_relationship
+			&& ! array_intersect( $link_rels, array( 'friend', 'acquaintance', 'contact' ) )
+		) {
+			echo ' checked="checked"';
+		}
+
+		if ( 'geographical' === $xfn_relationship
+			&& ! array_intersect( $link_rels, array( 'co-resident', 'neighbor' ) )
+		) {
+			echo ' checked="checked"';
+		}
+
+		// Mark the 'me' value as checked if it matches the current link's relationship.
+		if ( 'identity' === $xfn_relationship
+			&& in_array( 'me', $link_rels, true )
+		) {
+			echo ' checked="checked"';
+		}
+	}
+}
+
+/**
+ * Displays XFN form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_xfn_meta_box( $link ) {
+	?>
+<table class="links-table">
+	<tr>
+		<th scope="row"><label for="link_rel"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'rel:' ); ?></label></th>
+		<td><input type="text" name="link_rel" id="link_rel" value="<?php echo ( isset( $link->link_rel ) ? esc_attr( $link->link_rel ) : '' ); ?>" /></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'identity' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'identity' );
+				?>
+			</span></legend>
+			<label for="me">
+			<input type="checkbox" name="identity" value="me" id="me" <?php xfn_check( 'identity', 'me' ); ?> />
+			<?php _e( 'another web address of mine' ); ?></label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'friendship' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'friendship' );
+				?>
+			</span></legend>
+			<label for="contact">
+			<input class="valinp" type="radio" name="friendship" value="contact" id="contact" <?php xfn_check( 'friendship', 'contact' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'contact' ); ?>
+			</label>
+			<label for="acquaintance">
+			<input class="valinp" type="radio" name="friendship" value="acquaintance" id="acquaintance" <?php xfn_check( 'friendship', 'acquaintance' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'acquaintance' ); ?>
+			</label>
+			<label for="friend">
+			<input class="valinp" type="radio" name="friendship" value="friend" id="friend" <?php xfn_check( 'friendship', 'friend' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'friend' ); ?>
+			</label>
+			<label for="friendship">
+			<input name="friendship" type="radio" class="valinp" value="" id="friendship" <?php xfn_check( 'friendship' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'none' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"> <?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'physical' ); ?> </th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'physical' );
+				?>
+			</span></legend>
+			<label for="met">
+			<input class="valinp" type="checkbox" name="physical" value="met" id="met" <?php xfn_check( 'physical', 'met' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'met' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"> <?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'professional' ); ?> </th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'professional' );
+				?>
+			</span></legend>
+			<label for="co-worker">
+			<input class="valinp" type="checkbox" name="professional" value="co-worker" id="co-worker" <?php xfn_check( 'professional', 'co-worker' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'co-worker' ); ?>
+			</label>
+			<label for="colleague">
+			<input class="valinp" type="checkbox" name="professional" value="colleague" id="colleague" <?php xfn_check( 'professional', 'colleague' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'colleague' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'geographical' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'geographical' );
+				?>
+			</span></legend>
+			<label for="co-resident">
+			<input class="valinp" type="radio" name="geographical" value="co-resident" id="co-resident" <?php xfn_check( 'geographical', 'co-resident' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'co-resident' ); ?>
+			</label>
+			<label for="neighbor">
+			<input class="valinp" type="radio" name="geographical" value="neighbor" id="neighbor" <?php xfn_check( 'geographical', 'neighbor' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'neighbor' ); ?>
+			</label>
+			<label for="geographical">
+			<input class="valinp" type="radio" name="geographical" value="" id="geographical" <?php xfn_check( 'geographical' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'none' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'family' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'family' );
+				?>
+			</span></legend>
+			<label for="child">
+			<input class="valinp" type="radio" name="family" value="child" id="child" <?php xfn_check( 'family', 'child' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'child' ); ?>
+			</label>
+			<label for="kin">
+			<input class="valinp" type="radio" name="family" value="kin" id="kin" <?php xfn_check( 'family', 'kin' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'kin' ); ?>
+			</label>
+			<label for="parent">
+			<input class="valinp" type="radio" name="family" value="parent" id="parent" <?php xfn_check( 'family', 'parent' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'parent' ); ?>
+			</label>
+			<label for="sibling">
+			<input class="valinp" type="radio" name="family" value="sibling" id="sibling" <?php xfn_check( 'family', 'sibling' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'sibling' ); ?>
+			</label>
+			<label for="spouse">
+			<input class="valinp" type="radio" name="family" value="spouse" id="spouse" <?php xfn_check( 'family', 'spouse' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'spouse' ); ?>
+			</label>
+			<label for="family">
+			<input class="valinp" type="radio" name="family" value="" id="family" <?php xfn_check( 'family' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'none' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'romantic' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'romantic' );
+				?>
+			</span></legend>
+			<label for="muse">
+			<input class="valinp" type="checkbox" name="romantic" value="muse" id="muse" <?php xfn_check( 'romantic', 'muse' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'muse' ); ?>
+			</label>
+			<label for="crush">
+			<input class="valinp" type="checkbox" name="romantic" value="crush" id="crush" <?php xfn_check( 'romantic', 'crush' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'crush' ); ?>
+			</label>
+			<label for="date">
+			<input class="valinp" type="checkbox" name="romantic" value="date" id="date" <?php xfn_check( 'romantic', 'date' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'date' ); ?>
+			</label>
+			<label for="romantic">
+			<input class="valinp" type="checkbox" name="romantic" value="sweetheart" id="romantic" <?php xfn_check( 'romantic', 'sweetheart' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'sweetheart' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+
+</table>
+<p><?php _e( 'If the link is to a person, you can specify your relationship with them using the above form. If you would like to learn more about the idea check out <a href="https://gmpg.org/xfn/">XFN</a>.' ); ?></p>
+	<?php
+}
+
+/**
+ * Displays advanced link options form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_advanced_meta_box( $link ) {
+	?>
+<table class="links-table" cellpadding="0">
+	<tr>
+		<th scope="row"><label for="link_image"><?php _e( 'Image Address' ); ?></label></th>
+		<td><input type="text" name="link_image" class="code" id="link_image" maxlength="255" value="<?php echo ( isset( $link->link_image ) ? esc_attr( $link->link_image ) : '' ); ?>" /></td>
+	</tr>
+	<tr>
+		<th scope="row"><label for="rss_uri"><?php _e( 'RSS Address' ); ?></label></th>
+		<td><input name="link_rss" class="code" type="text" id="rss_uri" maxlength="255" value="<?php echo ( isset( $link->link_rss ) ? esc_attr( $link->link_rss ) : '' ); ?>" /></td>
+	</tr>
+	<tr>
+		<th scope="row"><label for="link_notes"><?php _e( 'Notes' ); ?></label></th>
+		<td><textarea name="link_notes" id="link_notes" rows="10"><?php echo ( isset( $link->link_notes ) ? $link->link_notes : '' ); // textarea_escaped ?></textarea></td>
+	</tr>
+	<tr>
+		<th scope="row"><label for="link_rating"><?php _e( 'Rating' ); ?></label></th>
+		<td><select name="link_rating" id="link_rating" size="1">
+		<?php
+		for ( $rating = 0; $rating <= 10; $rating++ ) {
+			echo '<option value="' . $rating . '"';
+			if ( isset( $link->link_rating ) && $link->link_rating === $rating ) {
+				echo ' selected="selected"';
+			}
+			echo '>' . $rating . '</option>';
+		}
+		?>
+		</select>&nbsp;<?php _e( '(Leave at 0 for no rating.)' ); ?>
+		</td>
+	</tr>
+</table>
+	<?php
+}
+
+/**
+ * Displays post thumbnail meta box.
+ *
+ * @since 2.9.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_thumbnail_meta_box( $post ) {
+	$thumbnail_id = get_post_meta( $post->ID, '_thumbnail_id', true );
+	echo _wp_post_thumbnail_html( $thumbnail_id, $post->ID );
+}
+
+/**
+ * Displays fields for ID3 data.
+ *
+ * @since 3.9.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function attachment_id3_data_meta_box( $post ) {
+	$meta = array();
+	if ( ! empty( $post->ID ) ) {
+		$meta = wp_get_attachment_metadata( $post->ID );
+	}
+
+	foreach ( wp_get_attachment_id3_keys( $post, 'edit' ) as $key => $label ) :
+		$value = '';
+		if ( ! empty( $meta[ $key ] ) ) {
+			$value = $meta[ $key ];
+		}
+		?>
+	<p>
+		<label for="title"><?php echo $label; ?></label><br />
+		<input type="text" name="id3_<?php echo esc_attr( $key ); ?>" id="id3_<?php echo esc_attr( $key ); ?>" class="large-text" value="<?php echo esc_attr( $value ); ?>" />
+	</p>
+		<?php
+	endforeach;
+}
+
+/**
+ * Registers the default post meta boxes, and runs the `do_meta_boxes` actions.
+ *
+ * @since 5.0.0
+ *
+ * @param WP_Post $post The post object that these meta boxes are being generated for.
+ */
+function register_and_do_post_meta_boxes( $post ) {
+	$post_type        = $post->post_type;
+	$post_type_object = get_post_type_object( $post_type );
+
+	$thumbnail_support = current_theme_supports( 'post-thumbnails', $post_type ) && post_type_supports( $post_type, 'thumbnail' );
+	if ( ! $thumbnail_support && 'attachment' === $post_type && $post->post_mime_type ) {
+		if ( wp_attachment_is( 'audio', $post ) ) {
+			$thumbnail_support = post_type_supports( 'attachment:audio', 'thumbnail' ) || current_theme_supports( 'post-thumbnails', 'attachment:audio' );
+		} elseif ( wp_attachment_is( 'video', $post ) ) {
+			$thumbnail_support = post_type_supports( 'attachment:video', 'thumbnail' ) || current_theme_supports( 'post-thumbnails', 'attachment:video' );
+		}
+	}
+
+	$publish_callback_args = array( '__back_compat_meta_box' => true );
+
+	if ( post_type_supports( $post_type, 'revisions' ) && 'auto-draft' !== $post->post_status ) {
+		$revisions = wp_get_latest_revision_id_and_total_count( $post->ID );
+
+		// We should aim to show the revisions meta box only when there are revisions.
+		if ( ! is_wp_error( $revisions ) && $revisions['count'] > 1 ) {
+			$publish_callback_args = array(
+				'revisions_count'        => $revisions['count'],
+				'revision_id'            => $revisions['latest_id'],
+				'__back_compat_meta_box' => true,
+			);
+
+			add_meta_box( 'revisionsdiv', __( 'Revisions' ), 'post_revisions_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+		}
+	}
+
+	if ( 'attachment' === $post_type ) {
+		wp_enqueue_script( 'image-edit' );
+		wp_enqueue_style( 'imgareaselect' );
+		add_meta_box( 'submitdiv', __( 'Save' ), 'attachment_submit_meta_box', null, 'side', 'core', array( '__back_compat_meta_box' => true ) );
+		add_action( 'edit_form_after_title', 'edit_form_image_editor' );
+
+		if ( wp_attachment_is( 'audio', $post ) ) {
+			add_meta_box( 'attachment-id3', __( 'Metadata' ), 'attachment_id3_data_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+		}
+	} else {
+		add_meta_box( 'submitdiv', __( 'Publish' ), 'post_submit_meta_box', null, 'side', 'core', $publish_callback_args );
+	}
+
+	if ( current_theme_supports( 'post-formats' ) && post_type_supports( $post_type, 'post-formats' ) ) {
+		add_meta_box( 'formatdiv', _x( 'Format', 'post format' ), 'post_format_meta_box', null, 'side', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	// All taxonomies.
+	foreach ( get_object_taxonomies( $post ) as $tax_name ) {
+		$taxonomy = get_taxonomy( $tax_name );
+		if ( ! $taxonomy->show_ui || false === $taxonomy->meta_box_cb ) {
+			continue;
+		}
+
+		$label = $taxonomy->labels->name;
+
+		if ( ! is_taxonomy_hierarchical( $tax_name ) ) {
+			$tax_meta_box_id = 'tagsdiv-' . $tax_name;
+		} else {
+			$tax_meta_box_id = $tax_name . 'div';
+		}
+
+		add_meta_box(
+			$tax_meta_box_id,
+			$label,
+			$taxonomy->meta_box_cb,
+			null,
+			'side',
+			'core',
+			array(
+				'taxonomy'               => $tax_name,
+				'__back_compat_meta_box' => true,
+			)
+		);
+	}
+
+	if ( post_type_supports( $post_type, 'page-attributes' ) || count( get_page_templates( $post ) ) > 0 ) {
+		add_meta_box( 'pageparentdiv', $post_type_object->labels->attributes, 'page_attributes_meta_box', null, 'side', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( $thumbnail_support && current_user_can( 'upload_files' ) ) {
+		add_meta_box( 'postimagediv', esc_html( $post_type_object->labels->featured_image ), 'post_thumbnail_meta_box', null, 'side', 'low', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'excerpt' ) ) {
+		add_meta_box( 'postexcerpt', __( 'Excerpt' ), 'post_excerpt_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'trackbacks' ) ) {
+		add_meta_box( 'trackbacksdiv', __( 'Send Trackbacks' ), 'post_trackback_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'custom-fields' ) ) {
+		add_meta_box(
+			'postcustom',
+			__( 'Custom Fields' ),
+			'post_custom_meta_box',
+			null,
+			'normal',
+			'core',
+			array(
+				'__back_compat_meta_box'             => ! (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
+				'__block_editor_compatible_meta_box' => true,
+			)
+		);
+	}
+
+	/**
+	 * Fires in the middle of built-in meta box registration.
+	 *
+	 * @since 2.1.0
+	 * @deprecated 3.7.0 Use {@see 'add_meta_boxes'} instead.
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action_deprecated( 'dbx_post_advanced', array( $post ), '3.7.0', 'add_meta_boxes' );
+
+	/*
+	 * Allow the Discussion meta box to show up if the post type supports comments,
+	 * or if comments or pings are open.
+	 */
+	if ( comments_open( $post ) || pings_open( $post ) || post_type_supports( $post_type, 'comments' ) ) {
+		add_meta_box( 'commentstatusdiv', __( 'Discussion' ), 'post_comment_status_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	$stati = get_post_stati( array( 'public' => true ) );
+	if ( empty( $stati ) ) {
+		$stati = array( 'publish' );
+	}
+	$stati[] = 'private';
+
+	if ( in_array( get_post_status( $post ), $stati, true ) ) {
+		/*
+		 * If the post type support comments, or the post has comments,
+		 * allow the Comments meta box.
+		 */
+		if ( comments_open( $post ) || pings_open( $post ) || $post->comment_count > 0 || post_type_supports( $post_type, 'comments' ) ) {
+			add_meta_box( 'commentsdiv', __( 'Comments' ), 'post_comment_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+		}
+	}
+
+	if ( ! ( 'pending' === get_post_status( $post ) && ! current_user_can( $post_type_object->cap->publish_posts ) ) ) {
+		add_meta_box( 'slugdiv', __( 'Slug' ), 'post_slug_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'author' ) && current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+		add_meta_box( 'authordiv', __( 'Author' ), 'post_author_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	/**
+	 * Fires after all built-in meta boxes have been added.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string  $post_type Post type.
+	 * @param WP_Post $post      Post object.
+	 */
+	do_action( 'add_meta_boxes', $post_type, $post );
+
+	/**
+	 * Fires after all built-in meta boxes have been added, contextually for the given post type.
+	 *
+	 * The dynamic portion of the hook name, `$post_type`, refers to the post type of the post.
+	 *
+	 * Possible hook names include:
+	 *
+	 *  - `add_meta_boxes_post`
+	 *  - `add_meta_boxes_page`
+	 *  - `add_meta_boxes_attachment`
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action( "add_meta_boxes_{$post_type}", $post );
+
+	/**
+	 * Fires after meta boxes have been added.
+	 *
+	 * Fires once for each of the default meta box contexts: normal, advanced, and side.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string                $post_type Post type of the post on Edit Post screen, 'link' on Edit Link screen,
+	 *                                         'dashboard' on Dashboard screen.
+	 * @param string                $context   Meta box context. Possible values include 'normal', 'advanced', 'side'.
+	 * @param WP_Post|object|string $post      Post object on Edit Post screen, link object on Edit Link screen,
+	 *                                         an empty string on Dashboard screen.
+	 */
+	do_action( 'do_meta_boxes', $post_type, 'normal', $post );
+	/** This action is documented in wp-admin/includes/meta-boxes.php */
+	do_action( 'do_meta_boxes', $post_type, 'advanced', $post );
+	/** This action is documented in wp-admin/includes/meta-boxes.php */
+	do_action( 'do_meta_boxes', $post_type, 'side', $post );
+}

--- a/tests/fixtures/Command/FormatPhp/wordpress/meta-boxes.out
+++ b/tests/fixtures/Command/FormatPhp/wordpress/meta-boxes.out
@@ -1,0 +1,1747 @@
+<?php
+/**
+ * WordPress Administration Meta Boxes API.
+ *
+ * @package WordPress
+ * @subpackage Administration
+ */
+
+//
+// Post-related Meta Boxes.
+//
+
+/**
+ * Displays post submit form fields.
+ *
+ * @since 2.7.0
+ *
+ * @global string $action
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $args {
+ *     Array of arguments for building the post submit meta box.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args     Extra meta box arguments.
+ * }
+ */
+function post_submit_meta_box( $post, $args = array() ) {
+	global $action;
+
+	$post_id          = (int) $post->ID;
+	$post_type        = $post->post_type;
+	$post_type_object = get_post_type_object( $post_type );
+	$can_publish      = current_user_can( $post_type_object->cap->publish_posts );
+?>
+<div class="submitbox" id="submitpost">
+
+<div id="minor-publishing">
+
+	<?php // Hidden submit button early on so that the browser chooses the right button when form is submitted with Return key. ?>
+	<div style="display:none;">
+		<?php submit_button( __( 'Save' ), '', 'save' ); ?>
+	</div>
+
+	<div id="minor-publishing-actions">
+		<div id="save-action">
+			<?php
+			if ( ! in_array( $post->post_status, array( 'publish', 'future', 'pending' ), true ) ) {
+				$private_style = '';
+				if ( 'private' === $post->post_status ) {
+					$private_style = 'style="display:none"';
+				}
+				?>
+				<input <?php echo $private_style; ?> type="submit" name="save" id="save-post" value="<?php esc_attr_e( 'Save Draft' ); ?>" class="button" />
+				<span class="spinner"></span>
+			<?php } elseif ( 'pending' === $post->post_status && $can_publish ) { ?>
+				<input type="submit" name="save" id="save-post" value="<?php esc_attr_e( 'Save as Pending' ); ?>" class="button" />
+				<span class="spinner"></span>
+			<?php } ?>
+		</div>
+
+		<?php
+		if ( is_post_type_viewable( $post_type_object ) ) :
+			?>
+			<div id="preview-action">
+				<?php
+				$preview_link = esc_url( get_preview_post_link( $post ) );
+				if ( 'publish' === $post->post_status ) {
+					$preview_button_text = __( 'Preview Changes' );
+				} else {
+					$preview_button_text = __( 'Preview' );
+				}
+
+				$preview_button = sprintf(
+					'%1$s<span class="screen-reader-text"> %2$s</span>',
+					$preview_button_text,
+					/* translators: Hidden accessibility text. */
+					__( '(opens in a new tab)' )
+				);
+				?>
+				<a class="preview button" href="<?php echo $preview_link; ?>" target="wp-preview-<?php echo $post_id; ?>" id="post-preview"><?php echo $preview_button; ?></a>
+				<input type="hidden" name="wp-preview" id="wp-preview" value="" />
+			</div>
+			<?php
+		endif;
+
+		/**
+		 * Fires after the Save Draft (or Save as Pending) and Preview (or Preview Changes) buttons
+		 * in the Publish meta box.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param WP_Post $post WP_Post object for the current post.
+		 */
+		do_action( 'post_submitbox_minor_actions', $post );
+		?>
+		<div class="clear"></div>
+	</div>
+
+	<div id="misc-publishing-actions">
+		<div class="misc-pub-section misc-pub-post-status">
+			<?php _e( 'Status:' ); ?>
+			<span id="post-status-display">
+				<?php
+				switch ( $post->post_status ) {
+					case 'private':
+						_e( 'Privately Published' );
+						break;
+					case 'publish':
+						_e( 'Published' );
+						break;
+					case 'future':
+						_e( 'Scheduled' );
+						break;
+					case 'pending':
+						_e( 'Pending Review' );
+						break;
+					case 'draft':
+					case 'auto-draft':
+						_e( 'Draft' );
+						break;
+				}
+				?>
+			</span>
+
+			<?php
+			if ( 'publish' === $post->post_status || 'private' === $post->post_status || $can_publish ) {
+				$private_style = '';
+				if ( 'private' === $post->post_status ) {
+					$private_style = 'style="display:none"';
+				}
+				?>
+				<a href="#post_status" <?php echo $private_style; ?> class="edit-post-status hide-if-no-js" role="button"><span aria-hidden="true"><?php _e( 'Edit' ); ?></span> <span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Edit status' );
+							?>
+				</span></a>
+
+				<div id="post-status-select" class="hide-if-js">
+					<input type="hidden" name="hidden_post_status" id="hidden_post_status" value="<?php echo esc_attr( ( 'auto-draft' === $post->post_status ) ? 'draft' : $post->post_status ); ?>" />
+					<label for="post_status" class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Set status' );
+								?>
+					</label>
+					<select name="post_status" id="post_status">
+						<?php if ( 'publish' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'publish' ); ?> value='publish'><?php _e( 'Published' ); ?></option>
+						<?php elseif ( 'private' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'private' ); ?> value='publish'><?php _e( 'Privately Published' ); ?></option>
+						<?php elseif ( 'future' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'future' ); ?> value='future'><?php _e( 'Scheduled' ); ?></option>
+						<?php endif; ?>
+							<option<?php selected( $post->post_status, 'pending' ); ?> value='pending'><?php _e( 'Pending Review' ); ?></option>
+						<?php if ( 'auto-draft' === $post->post_status ) : ?>
+							<option<?php selected( $post->post_status, 'auto-draft' ); ?> value='draft'><?php _e( 'Draft' ); ?></option>
+						<?php else : ?>
+							<option<?php selected( $post->post_status, 'draft' ); ?> value='draft'><?php _e( 'Draft' ); ?></option>
+						<?php endif; ?>
+					</select>
+					<a href="#post_status" class="save-post-status hide-if-no-js button"><?php _e( 'OK' ); ?></a>
+					<a href="#post_status" class="cancel-post-status hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
+				</div>
+				<?php
+			}
+						?>
+		</div>
+
+		<div class="misc-pub-section misc-pub-visibility" id="visibility">
+			<?php _e( 'Visibility:' ); ?>
+			<span id="post-visibility-display">
+				<?php
+				if ( 'private' === $post->post_status ) {
+					$post->post_password = '';
+					$visibility          = 'private';
+					$visibility_trans    = __( 'Private' );
+				} elseif ( ! empty( $post->post_password ) ) {
+					$visibility       = 'password';
+					$visibility_trans = __( 'Password protected' );
+				} elseif ( 'post' === $post_type && is_sticky( $post_id ) ) {
+					$visibility       = 'public';
+					$visibility_trans = __( 'Public, Sticky' );
+				} else {
+					$visibility       = 'public';
+					$visibility_trans = __( 'Public' );
+				}
+
+				echo esc_html( $visibility_trans );
+				?>
+			</span>
+
+			<?php if ( $can_publish ) { ?>
+				<a href="#visibility" class="edit-visibility hide-if-no-js" role="button"><span aria-hidden="true"><?php _e( 'Edit' ); ?></span> <span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Edit visibility' );
+					?>
+				</span></a>
+
+				<div id="post-visibility-select" class="hide-if-js">
+					<input type="hidden" name="hidden_post_password" id="hidden-post-password" value="<?php echo esc_attr( $post->post_password ); ?>" />
+					<?php if ( 'post' === $post_type ) : ?>
+						<input type="checkbox" style="display:none" name="hidden_post_sticky" id="hidden-post-sticky" value="sticky" <?php checked( is_sticky( $post_id ) ); ?> />
+					<?php endif; ?>
+
+					<input type="hidden" name="hidden_post_visibility" id="hidden-post-visibility" value="<?php echo esc_attr( $visibility ); ?>" />
+					<input type="radio" name="visibility" id="visibility-radio-public" value="public" <?php checked( $visibility, 'public' ); ?> /> <label for="visibility-radio-public" class="selectit"><?php _e( 'Public' ); ?></label><br />
+
+					<?php if ( 'post' === $post_type && current_user_can( 'edit_others_posts' ) ) : ?>
+						<span id="sticky-span"><input id="sticky" name="sticky" type="checkbox" value="sticky" <?php checked( is_sticky( $post_id ) ); ?> /> <label for="sticky" class="selectit"><?php _e( 'Stick this post to the front page' ); ?></label><br /></span>
+					<?php endif; ?>
+
+					<input type="radio" name="visibility" id="visibility-radio-password" value="password" <?php checked( $visibility, 'password' ); ?> /> <label for="visibility-radio-password" class="selectit"><?php _e( 'Password protected' ); ?></label><br />
+					<span id="password-span"><label for="post_password"><?php _e( 'Password:' ); ?></label> <input type="text" name="post_password" id="post_password" value="<?php echo esc_attr( $post->post_password ); ?>"  maxlength="255" /><br /></span>
+
+					<input type="radio" name="visibility" id="visibility-radio-private" value="private" <?php checked( $visibility, 'private' ); ?> /> <label for="visibility-radio-private" class="selectit"><?php _e( 'Private' ); ?></label><br />
+
+					<p>
+						<a href="#visibility" class="save-post-visibility hide-if-no-js button"><?php _e( 'OK' ); ?></a>
+						<a href="#visibility" class="cancel-post-visibility hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
+					</p>
+				</div>
+			<?php } ?>
+		</div>
+
+		<?php
+		/* translators: Publish box date string. 1: Date, 2: Time. See https://www.php.net/manual/datetime.format.php */
+		$date_string = __( '%1$s at %2$s' );
+		/* translators: Publish box date format, see https://www.php.net/manual/datetime.format.php */
+		$date_format = _x( 'M j, Y', 'publish box date format' );
+		/* translators: Publish box time format, see https://www.php.net/manual/datetime.format.php */
+		$time_format = _x( 'H:i', 'publish box time format' );
+
+		if ( 0 !== $post_id ) {
+			if ( 'future' === $post->post_status ) { // Scheduled for publishing at a future date.
+				/* translators: Post date information. %s: Date on which the post is currently scheduled to be published. */
+				$stamp = __( 'Scheduled for: %s' );
+			} elseif ( 'publish' === $post->post_status || 'private' === $post->post_status ) { // Already published.
+				/* translators: Post date information. %s: Date on which the post was published. */
+				$stamp = __( 'Published on: %s' );
+			} elseif ( '0000-00-00 00:00:00' === $post->post_date_gmt ) { // Draft, 1 or more saves, no date specified.
+				$stamp = __( 'Publish <b>immediately</b>' );
+			} elseif ( time() < strtotime( $post->post_date_gmt . ' +0000' ) ) { // Draft, 1 or more saves, future date specified.
+				/* translators: Post date information. %s: Date on which the post is to be published. */
+				$stamp = __( 'Schedule for: %s' );
+			} else { // Draft, 1 or more saves, date specified.
+				/* translators: Post date information. %s: Date on which the post is to be published. */
+				$stamp = __( 'Publish on: %s' );
+			}
+			$date = sprintf(
+				$date_string,
+				date_i18n( $date_format, strtotime( $post->post_date ) ),
+				date_i18n( $time_format, strtotime( $post->post_date ) )
+			);
+		} else { // Draft (no saves, and thus no date specified).
+			$stamp = __( 'Publish <b>immediately</b>' );
+			$date  = sprintf(
+				$date_string,
+				date_i18n( $date_format, strtotime( current_time( 'mysql' ) ) ),
+				date_i18n( $time_format, strtotime( current_time( 'mysql' ) ) )
+			);
+		}
+
+		if ( ! empty( $args['args']['revisions_count'] ) ) :
+			?>
+			<div class="misc-pub-section misc-pub-revisions">
+				<?php
+				/* translators: Post revisions heading. %s: The number of available revisions. */
+				printf( __( 'Revisions: %s' ), '<b>' . number_format_i18n( $args['args']['revisions_count'] ) . '</b>' );
+				?>
+				<a class="hide-if-no-js" href="<?php echo esc_url( get_edit_post_link( $args['args']['revision_id'] ) ); ?>"><span aria-hidden="true"><?php _ex( 'Browse', 'revisions' ); ?></span> <span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Browse revisions' );
+						?>
+				</span></a>
+			</div>
+			<?php
+		endif;
+
+		if ( $can_publish ) : // Contributors don't get to choose the date of publish.
+			?>
+			<div class="misc-pub-section curtime misc-pub-curtime">
+				<span id="timestamp">
+					<?php printf( $stamp, '<b>' . $date . '</b>' ); ?>
+				</span>
+				<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
+					<span aria-hidden="true"><?php _e( 'Edit' ); ?></span>
+					<span class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Edit date and time' );
+							?>
+					</span>
+				</a>
+				<fieldset id="timestampdiv" class="hide-if-js">
+					<legend class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Date and time' );
+							?>
+					</legend>
+					<?php touch_time( ( 'edit' === $action ), 1 ); ?>
+				</fieldset>
+			</div>
+			<?php
+		endif;
+
+		if ( 'draft' === $post->post_status && get_post_meta( $post_id, '_customize_changeset_uuid', true ) ) :
+			$message = sprintf(
+				/* translators: %s: URL to the Customizer. */
+				__( 'This draft comes from your <a href="%s">unpublished customization changes</a>. You can edit, but there is no need to publish now. It will be published automatically with those changes.' ),
+				esc_url(
+					add_query_arg(
+						'changeset_uuid',
+						rawurlencode( get_post_meta( $post_id, '_customize_changeset_uuid', true ) ),
+						admin_url( 'customize.php' )
+					)
+				)
+			);
+			wp_admin_notice(
+				$message,
+				array(
+					'type'               => 'info',
+					'additional_classes' => array( 'notice-alt', 'inline' ),
+				)
+			);
+		endif;
+
+		/**
+		 * Fires after the post time/date setting in the Publish meta box.
+		 *
+		 * @since 2.9.0
+		 * @since 4.4.0 Added the `$post` parameter.
+		 *
+		 * @param WP_Post $post WP_Post object for the current post.
+		 */
+		do_action( 'post_submitbox_misc_actions', $post );
+				?>
+	</div>
+	<div class="clear"></div>
+</div>
+
+<div id="major-publishing-actions">
+	<?php
+	/**
+	 * Fires at the beginning of the publishing actions section of the Publish meta box.
+	 *
+	 * @since 2.7.0
+	 * @since 4.9.0 Added the `$post` parameter.
+	 *
+	 * @param WP_Post|null $post WP_Post object for the current post on Edit Post screen,
+	 *                           null on Edit Link screen.
+	 */
+	do_action( 'post_submitbox_start', $post );
+	?>
+	<div id="delete-action">
+		<?php
+		if ( current_user_can( 'delete_post', $post_id ) ) {
+			if ( ! EMPTY_TRASH_DAYS ) {
+				$delete_text = __( 'Delete permanently' );
+			} else {
+				$delete_text = __( 'Move to Trash' );
+			}
+			?>
+			<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post_id ); ?>"><?php echo $delete_text; ?></a>
+			<?php
+		}
+				?>
+	</div>
+
+	<div id="publishing-action">
+		<span class="spinner"></span>
+		<?php
+		if ( ! in_array( $post->post_status, array( 'publish', 'future', 'private' ), true ) || 0 === $post_id ) {
+			if ( $can_publish ) :
+				if ( ! empty( $post->post_date_gmt ) && time() < strtotime( $post->post_date_gmt . ' +0000' ) ) :
+					?>
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php echo esc_attr_x( 'Schedule', 'post action/button label' ); ?>" />
+					<?php submit_button( _x( 'Schedule', 'post action/button label' ), 'primary large', 'publish', false ); ?>
+					<?php
+				else :
+					?>
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Publish' ); ?>" />
+					<?php submit_button( __( 'Publish' ), 'primary large', 'publish', false ); ?>
+					<?php
+				endif;
+			else :
+				?>
+				<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Submit for Review' ); ?>" />
+				<?php submit_button( __( 'Submit for Review' ), 'primary large', 'publish', false ); ?>
+				<?php
+			endif;
+		} else {
+			?>
+			<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Update' ); ?>" />
+			<?php submit_button( __( 'Update' ), 'primary large', 'save', false, array( 'id' => 'publish' ) ); ?>
+			<?php
+		}
+				?>
+	</div>
+	<div class="clear"></div>
+</div>
+
+</div>
+	<?php
+}
+
+/**
+ * Displays attachment submit form fields.
+ *
+ * @since 3.5.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function attachment_submit_meta_box( $post ) {
+	?>
+<div class="submitbox" id="submitpost">
+
+<div id="minor-publishing">
+
+	<?php // Hidden submit button early on so that the browser chooses the right button when form is submitted with Return key. ?>
+<div style="display:none;">
+	<?php submit_button( __( 'Save' ), '', 'save' ); ?>
+</div>
+
+
+<div id="misc-publishing-actions">
+	<div class="misc-pub-section curtime misc-pub-curtime">
+		<span id="timestamp">
+			<?php
+			$uploaded_on = sprintf(
+				/* translators: Publish box date string. 1: Date, 2: Time. */
+				__( '%1$s at %2$s' ),
+				/* translators: Publish box date format, see https://www.php.net/manual/datetime.format.php */
+				date_i18n( _x( 'M j, Y', 'publish box date format' ), strtotime( $post->post_date ) ),
+				/* translators: Publish box time format, see https://www.php.net/manual/datetime.format.php */
+				date_i18n( _x( 'H:i', 'publish box time format' ), strtotime( $post->post_date ) )
+			);
+			/* translators: Attachment information. %s: Date the attachment was uploaded. */
+			printf( __( 'Uploaded on: %s' ), '<b>' . $uploaded_on . '</b>' );
+			?>
+		</span>
+	</div><!-- .misc-pub-section -->
+
+	<?php
+	/**
+	 * Fires after the 'Uploaded on' section of the Save meta box
+	 * in the attachment editing screen.
+	 *
+	 * @since 3.5.0
+	 * @since 4.9.0 Added the `$post` parameter.
+	 *
+	 * @param WP_Post $post WP_Post object for the current attachment.
+	 */
+	do_action( 'attachment_submitbox_misc_actions', $post );
+	?>
+</div><!-- #misc-publishing-actions -->
+<div class="clear"></div>
+</div><!-- #minor-publishing -->
+
+<div id="major-publishing-actions">
+	<div id="delete-action">
+	<?php
+	if ( current_user_can( 'delete_post', $post->ID ) ) {
+		if ( EMPTY_TRASH_DAYS && MEDIA_TRASH ) {
+			printf(
+				'<a class="submitdelete deletion" href="%1$s">%2$s</a>',
+				get_delete_post_link( $post->ID ),
+				__( 'Move to Trash' )
+			);
+		} else {
+			$show_confirmation = ! MEDIA_TRASH ? " onclick='return showNotice.warn();'" : '';
+
+			printf(
+				'<a class="submitdelete deletion"%1$s href="%2$s">%3$s</a>',
+				$show_confirmation,
+				get_delete_post_link( $post->ID, '', true ),
+				__( 'Delete permanently' )
+			);
+		}
+	}
+	?>
+	</div>
+
+	<div id="publishing-action">
+		<span class="spinner"></span>
+		<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Update' ); ?>" />
+		<input name="save" type="submit" class="button button-primary button-large" id="publish" value="<?php esc_attr_e( 'Update' ); ?>" />
+	</div>
+	<div class="clear"></div>
+</div><!-- #major-publishing-actions -->
+
+</div>
+
+	<?php
+}
+
+/**
+ * Displays post format form elements.
+ *
+ * @since 3.1.0
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box {
+ *     Post formats meta box arguments.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args     Extra meta box arguments.
+ * }
+ */
+function post_format_meta_box( $post, $box ) {
+	if ( current_theme_supports( 'post-formats' ) && post_type_supports( $post->post_type, 'post-formats' ) ) :
+		$post_formats = get_theme_support( 'post-formats' );
+
+		if ( is_array( $post_formats[0] ) ) :
+			$post_format = get_post_format( $post->ID );
+			if ( ! $post_format ) {
+				$post_format = '0';
+			}
+			// Add in the current one if it isn't there yet, in case the active theme doesn't support it.
+			if ( $post_format && ! in_array( $post_format, $post_formats[0], true ) ) {
+				$post_formats[0][] = $post_format;
+			}
+	?>
+		<div id="post-formats-select">
+		<fieldset>
+			<legend class="screen-reader-text">
+				<?php
+				/* translators: Hidden accessibility text. */
+				_e( 'Post Formats' );
+				?>
+			</legend>
+			<input type="radio" name="post_format" class="post-format" id="post-format-0" value="0" <?php checked( $post_format, '0' ); ?> /> <label for="post-format-0" class="post-format-icon post-format-standard"><?php echo get_post_format_string( 'standard' ); ?></label>
+			<?php foreach ( $post_formats[0] as $format ) : ?>
+			<br /><input type="radio" name="post_format" class="post-format" id="post-format-<?php echo esc_attr( $format ); ?>" value="<?php echo esc_attr( $format ); ?>" <?php checked( $post_format, $format ); ?> /> <label for="post-format-<?php echo esc_attr( $format ); ?>" class="post-format-icon post-format-<?php echo esc_attr( $format ); ?>"><?php echo esc_html( get_post_format_string( $format ) ); ?></label>
+			<?php endforeach; ?>
+		</fieldset>
+	</div>
+			<?php
+		endif;
+	endif;
+}
+
+/**
+ * Displays post tags form fields.
+ *
+ * @since 2.6.0
+ *
+ * @todo Create taxonomy-agnostic wrapper for this.
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box {
+ *     Tags meta box arguments.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args {
+ *         Extra meta box arguments.
+ *
+ *         @type string $taxonomy Taxonomy. Default 'post_tag'.
+ *     }
+ * }
+ */
+function post_tags_meta_box( $post, $box ) {
+	$defaults = array( 'taxonomy' => 'post_tag' );
+	if ( ! isset( $box['args'] ) || ! is_array( $box['args'] ) ) {
+		$args = array();
+	} else {
+		$args = $box['args'];
+	}
+	$parsed_args           = wp_parse_args( $args, $defaults );
+	$tax_name              = esc_attr( $parsed_args['taxonomy'] );
+	$taxonomy              = get_taxonomy( $parsed_args['taxonomy'] );
+	$user_can_assign_terms = current_user_can( $taxonomy->cap->assign_terms );
+	$comma                 = _x( ',', 'tag delimiter' );
+	$terms_to_edit         = get_terms_to_edit( $post->ID, $tax_name );
+	if ( ! is_string( $terms_to_edit ) ) {
+		$terms_to_edit = '';
+	}
+			?>
+<div class="tagsdiv" id="<?php echo $tax_name; ?>">
+	<div class="jaxtag">
+	<div class="nojs-tags hide-if-js">
+		<label for="tax-input-<?php echo $tax_name; ?>"><?php echo $taxonomy->labels->add_or_remove_items; ?></label>
+		<p><textarea name="<?php echo "tax_input[$tax_name]"; ?>" rows="3" cols="20" class="the-tags" id="tax-input-<?php echo $tax_name; ?>" <?php disabled( ! $user_can_assign_terms ); ?> aria-describedby="new-tag-<?php echo $tax_name; ?>-desc"><?php echo str_replace( ',', $comma . ' ', $terms_to_edit ); // textarea_escaped by esc_attr() ?></textarea></p>
+	</div>
+	<?php if ( $user_can_assign_terms ) : ?>
+	<div class="ajaxtag hide-if-no-js">
+		<label class="screen-reader-text" for="new-tag-<?php echo $tax_name; ?>"><?php echo $taxonomy->labels->add_new_item; ?></label>
+		<input data-wp-taxonomy="<?php echo $tax_name; ?>" type="text" id="new-tag-<?php echo $tax_name; ?>" name="newtag[<?php echo $tax_name; ?>]" class="newtag form-input-tip" size="16" autocomplete="off" aria-describedby="new-tag-<?php echo $tax_name; ?>-desc" value="" />
+		<input type="button" class="button tagadd" value="<?php esc_attr_e( 'Add' ); ?>" />
+	</div>
+	<p class="howto" id="new-tag-<?php echo $tax_name; ?>-desc"><?php echo $taxonomy->labels->separate_items_with_commas; ?></p>
+	<?php elseif ( empty( $terms_to_edit ) ) : ?>
+		<p><?php echo $taxonomy->labels->no_terms; ?></p>
+	<?php endif; ?>
+	</div>
+	<ul class="tagchecklist" role="list"></ul>
+</div>
+	<?php if ( $user_can_assign_terms ) : ?>
+<p class="hide-if-no-js"><button type="button" class="button-link tagcloud-link" id="link-<?php echo $tax_name; ?>" aria-expanded="false"><?php echo $taxonomy->labels->choose_from_most_used; ?></button></p>
+<?php endif; ?>
+	<?php
+}
+
+/**
+ * Displays post categories form fields.
+ *
+ * @since 2.6.0
+ *
+ * @todo Create taxonomy-agnostic wrapper for this.
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box {
+ *     Categories meta box arguments.
+ *
+ *     @type string   $id       Meta box 'id' attribute.
+ *     @type string   $title    Meta box title.
+ *     @type callable $callback Meta box display callback.
+ *     @type array    $args {
+ *         Extra meta box arguments.
+ *
+ *         @type string $taxonomy Taxonomy. Default 'category'.
+ *     }
+ * }
+ */
+function post_categories_meta_box( $post, $box ) {
+	$defaults = array( 'taxonomy' => 'category' );
+	if ( ! isset( $box['args'] ) || ! is_array( $box['args'] ) ) {
+		$args = array();
+	} else {
+		$args = $box['args'];
+	}
+	$parsed_args = wp_parse_args( $args, $defaults );
+	$tax_name    = esc_attr( $parsed_args['taxonomy'] );
+	$taxonomy    = get_taxonomy( $parsed_args['taxonomy'] );
+	?>
+	<div id="taxonomy-<?php echo $tax_name; ?>" class="categorydiv">
+		<ul id="<?php echo $tax_name; ?>-tabs" class="category-tabs">
+			<li class="tabs"><a href="#<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
+			<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop"><?php echo esc_html( $taxonomy->labels->most_used ); ?></a></li>
+		</ul>
+
+		<div id="<?php echo $tax_name; ?>-pop" class="tabs-panel" style="display: none;">
+			<ul id="<?php echo $tax_name; ?>checklist-pop" class="categorychecklist form-no-clear" >
+				<?php $popular_ids = wp_popular_terms_checklist( $tax_name ); ?>
+			</ul>
+		</div>
+
+		<div id="<?php echo $tax_name; ?>-all" class="tabs-panel">
+			<?php
+			$name = ( 'category' === $tax_name ) ? 'post_category' : 'tax_input[' . $tax_name . ']';
+			// Allows for an empty term set to be sent. 0 is an invalid term ID and will be ignored by empty() checks.
+			echo "<input type='hidden' name='{$name}[]' value='0' />";
+			?>
+			<ul id="<?php echo $tax_name; ?>checklist" data-wp-lists="list:<?php echo $tax_name; ?>" class="categorychecklist form-no-clear">
+				<?php
+				wp_terms_checklist(
+					$post->ID,
+					array(
+						'taxonomy'     => $tax_name,
+						'popular_cats' => $popular_ids,
+					)
+				);
+				?>
+			</ul>
+		</div>
+	<?php if ( current_user_can( $taxonomy->cap->edit_terms ) ) : ?>
+			<div id="<?php echo $tax_name; ?>-adder" class="wp-hidden-children">
+				<a id="<?php echo $tax_name; ?>-add-toggle" href="#<?php echo $tax_name; ?>-add" class="hide-if-no-js taxonomy-add-new">
+					<?php
+					/* translators: %s: Add New taxonomy label. */
+					printf( __( '+ %s' ), $taxonomy->labels->add_new_item );
+					?>
+				</a>
+				<p id="<?php echo $tax_name; ?>-add" class="category-add wp-hidden-child">
+					<label class="screen-reader-text" for="new<?php echo $tax_name; ?>"><?php echo $taxonomy->labels->add_new_item; ?></label>
+					<input type="text" name="new<?php echo $tax_name; ?>" id="new<?php echo $tax_name; ?>" class="form-required form-input-tip" value="<?php echo esc_attr( $taxonomy->labels->new_item_name ); ?>" aria-required="true" />
+					<label class="screen-reader-text" for="new<?php echo $tax_name; ?>_parent">
+						<?php echo $taxonomy->labels->parent_item_colon; ?>
+					</label>
+					<?php
+					$parent_dropdown_args = array(
+						'taxonomy'         => $tax_name,
+						'hide_empty'       => 0,
+						'name'             => 'new' . $tax_name . '_parent',
+						'orderby'          => 'name',
+						'hierarchical'     => 1,
+						'show_option_none' => '&mdash; ' . $taxonomy->labels->parent_item . ' &mdash;',
+					);
+
+					/**
+					 * Filters the arguments for the taxonomy parent dropdown on the Post Edit page.
+					 *
+					 * @since 4.4.0
+					 *
+					 * @param array $parent_dropdown_args {
+					 *     Optional. Array of arguments to generate parent dropdown.
+					 *
+					 *     @type string   $taxonomy         Name of the taxonomy to retrieve.
+					 *     @type bool     $hide_if_empty    True to skip generating markup if no
+					 *                                      categories are found. Default 0.
+					 *     @type string   $name             Value for the 'name' attribute
+					 *                                      of the select element.
+					 *                                      Default "new{$tax_name}_parent".
+					 *     @type string   $orderby          Which column to use for ordering
+					 *                                      terms. Default 'name'.
+					 *     @type bool|int $hierarchical     Whether to traverse the taxonomy
+					 *                                      hierarchy. Default 1.
+					 *     @type string   $show_option_none Text to display for the "none" option.
+					 *                                      Default "&mdash; {$parent} &mdash;",
+					 *                                      where `$parent` is 'parent_item'
+					 *                                      taxonomy label.
+					 * }
+					 */
+					$parent_dropdown_args = apply_filters( 'post_edit_category_parent_dropdown_args', $parent_dropdown_args );
+
+					wp_dropdown_categories( $parent_dropdown_args );
+					?>
+					<input type="button" id="<?php echo $tax_name; ?>-add-submit" data-wp-lists="add:<?php echo $tax_name; ?>checklist:<?php echo $tax_name; ?>-add" class="button category-add-submit" value="<?php echo esc_attr( $taxonomy->labels->add_new_item ); ?>" />
+					<?php wp_nonce_field( 'add-' . $tax_name, '_ajax_nonce-add-' . $tax_name, false ); ?>
+					<span id="<?php echo $tax_name; ?>-ajax-response"></span>
+				</p>
+			</div>
+		<?php endif; ?>
+	</div>
+	<?php
+}
+
+/**
+ * Displays post excerpt form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_excerpt_meta_box( $post ) {
+	?>
+<label class="screen-reader-text" for="excerpt">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Excerpt' );
+	?>
+</label><textarea rows="1" cols="40" name="excerpt" id="excerpt"><?php echo $post->post_excerpt; // textarea_escaped ?></textarea>
+<p>
+	<?php
+	printf(
+		/* translators: %s: Documentation URL. */
+		__( 'Excerpts are optional hand-crafted summaries of your content that can be used in your theme. <a href="%s">Learn more about manual excerpts</a>.' ),
+		__( 'https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/' )
+	);
+	?>
+</p>
+	<?php
+}
+
+/**
+ * Displays trackback links form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_trackback_meta_box( $post ) {
+	$form_trackback = '<input type="text" name="trackback_url" id="trackback_url" class="code" value="' .
+		esc_attr( str_replace( "\n", ' ', $post->to_ping ) ) . '" aria-describedby="trackback-url-desc" />';
+
+	if ( '' !== $post->pinged ) {
+		$pings          = '<p>' . __( 'Already pinged:' ) . '</p><ul>';
+		$already_pinged = explode( "\n", trim( $post->pinged ) );
+		foreach ( $already_pinged as $pinged_url ) {
+			$pings .= "\n\t<li>" . esc_html( $pinged_url ) . '</li>';
+		}
+		$pings .= '</ul>';
+	}
+
+	?>
+<p>
+	<label for="trackback_url"><?php _e( 'Send trackbacks to:' ); ?></label>
+	<?php echo $form_trackback; ?>
+</p>
+<p id="trackback-url-desc" class="howto"><?php _e( 'Separate multiple URLs with spaces' ); ?></p>
+<p>
+	<?php
+	printf(
+		/* translators: %s: Documentation URL. */
+		__( 'Trackbacks are a way to notify legacy blog systems that you&#8217;ve linked to them. If you link other WordPress sites, they&#8217;ll be notified automatically using <a href="%s">pingbacks</a>, no other action necessary.' ),
+		__( 'https://wordpress.org/documentation/article/introduction-to-blogging/#comments' )
+	);
+	?>
+</p>
+	<?php
+	if ( ! empty( $pings ) ) {
+		echo $pings;
+	}
+}
+
+/**
+ * Displays custom fields form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_custom_meta_box( $post ) {
+	?>
+<div id="postcustomstuff">
+<div id="ajax-response"></div>
+	<?php
+	$metadata = has_meta( $post->ID );
+	foreach ( $metadata as $key => $value ) {
+		if ( is_protected_meta( $metadata[ $key ]['meta_key'], 'post' ) || ! current_user_can( 'edit_post_meta', $post->ID, $metadata[ $key ]['meta_key'] ) ) {
+			unset( $metadata[ $key ] );
+		}
+	}
+	list_meta( $metadata );
+	meta_form( $post );
+	?>
+</div>
+<p>
+	<?php
+	printf(
+		/* translators: %s: Documentation URL. */
+		__( 'Custom fields can be used to add extra metadata to a post that you can <a href="%s">use in your theme</a>.' ),
+		__( 'https://wordpress.org/documentation/article/assign-custom-fields/' )
+	);
+	?>
+</p>
+	<?php
+}
+
+/**
+ * Displays comments status form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_comment_status_meta_box( $post ) {
+	?>
+<input name="advanced_view" type="hidden" value="1" />
+<p class="meta-options">
+	<label for="comment_status" class="selectit"><input name="comment_status" type="checkbox" id="comment_status" value="open" <?php checked( $post->comment_status, 'open' ); ?> /> <?php _e( 'Allow comments' ); ?></label><br />
+	<label for="ping_status" class="selectit"><input name="ping_status" type="checkbox" id="ping_status" value="open" <?php checked( $post->ping_status, 'open' ); ?> />
+		<?php
+		printf(
+			/* translators: %s: Documentation URL. */
+			__( 'Allow <a href="%s">trackbacks and pingbacks</a>' ),
+			__( 'https://wordpress.org/documentation/article/introduction-to-blogging/#managing-comments' )
+		);
+		?>
+	</label>
+	<?php
+	/**
+	 * Fires at the end of the Discussion meta box on the post editing screen.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Post $post WP_Post object for the current post.
+	 */
+	do_action( 'post_comment_status_meta_box-options', $post ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	?>
+</p>
+	<?php
+}
+
+/**
+ * Displays comments for post table header
+ *
+ * @since 3.0.0
+ *
+ * @param array $result Table header rows.
+ * @return array
+ */
+function post_comment_meta_box_thead( $result ) {
+	unset( $result['cb'], $result['response'] );
+	return $result;
+}
+
+/**
+ * Displays comments for post.
+ *
+ * @since 2.8.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_comment_meta_box( $post ) {
+	wp_nonce_field( 'get-comments', 'add_comment_nonce', false );
+	?>
+	<p class="hide-if-no-js" id="add-new-comment"><button type="button" class="button" onclick="window.commentReply && commentReply.addcomment(<?php echo $post->ID; ?>);"><?php _e( 'Add Comment' ); ?></button></p>
+	<?php
+
+	$total         = get_comments(
+		array(
+			'post_id' => $post->ID,
+			'count'   => true,
+			'orderby' => 'none',
+		)
+	);
+	$wp_list_table = _get_list_table( 'WP_Post_Comments_List_Table' );
+	$wp_list_table->display( true );
+
+	if ( 1 > $total ) {
+		echo '<p id="no-comments">' . __( 'No comments yet.' ) . '</p>';
+	} else {
+		$hidden = get_hidden_meta_boxes( get_current_screen() );
+		if ( ! in_array( 'commentsdiv', $hidden, true ) ) {
+			?>
+			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
+			<?php
+		}
+
+		?>
+		<p class="hide-if-no-js" id="show-comments"><a href="#commentstatusdiv" onclick="commentsBox.load(<?php echo $total; ?>);return false;"><?php _e( 'Show comments' ); ?></a> <span class="spinner"></span></p>
+		<?php
+	}
+
+	wp_comment_trashnotice();
+}
+
+/**
+ * Displays slug form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_slug_meta_box( $post ) {
+	/** This filter is documented in wp-admin/edit-tag-form.php */
+	$editable_slug = apply_filters( 'editable_slug', $post->post_name, $post );
+		?>
+<label class="screen-reader-text" for="post_name">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Slug' );
+	?>
+</label><input name="post_name" type="text" class="large-text" id="post_name" value="<?php echo esc_attr( $editable_slug ); ?>" />
+	<?php
+}
+
+/**
+ * Displays form field with list of authors.
+ *
+ * @since 2.6.0
+ *
+ * @global int $user_ID
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_author_meta_box( $post ) {
+	global $user_ID;
+
+	$post_type_object = get_post_type_object( $post->post_type );
+	?>
+<label class="screen-reader-text" for="post_author_override">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Author' );
+	?>
+</label>
+	<?php
+	wp_dropdown_users(
+		array(
+			'capability'       => array( $post_type_object->cap->edit_posts ),
+			'name'             => 'post_author_override',
+			'selected'         => empty( $post->ID ) ? $user_ID : $post->post_author,
+			'include_selected' => true,
+			'show'             => 'display_name_with_login',
+		)
+	);
+}
+
+/**
+ * Displays list of revisions.
+ *
+ * @since 2.6.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_revisions_meta_box( $post ) {
+	wp_list_post_revisions( $post );
+}
+
+//
+// Page-related Meta Boxes.
+//
+
+/**
+ * Displays page attributes form fields.
+ *
+ * @since 2.7.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function page_attributes_meta_box( $post ) {
+	if ( is_post_type_hierarchical( $post->post_type ) ) :
+		$dropdown_args = array(
+			'post_type'        => $post->post_type,
+			'exclude_tree'     => $post->ID,
+			'selected'         => $post->post_parent,
+			'name'             => 'parent_id',
+			'show_option_none' => __( '(no parent)' ),
+			'sort_column'      => 'menu_order, post_title',
+			'echo'             => 0,
+		);
+
+		/**
+		 * Filters the arguments used to generate a Pages drop-down element.
+		 *
+		 * @since 3.3.0
+		 *
+		 * @see wp_dropdown_pages()
+		 *
+		 * @param array   $dropdown_args Array of arguments used to generate the pages drop-down.
+		 * @param WP_Post $post          The current post.
+		 */
+		$dropdown_args = apply_filters( 'page_attributes_dropdown_pages_args', $dropdown_args, $post );
+		$pages = wp_dropdown_pages( $dropdown_args );
+		if ( ! empty( $pages ) ) :
+	?>
+<p class="post-attributes-label-wrapper parent-id-label-wrapper"><label class="post-attributes-label" for="parent_id"><?php _e( 'Parent' ); ?></label></p>
+			<?php echo $pages; ?>
+			<?php
+		endif; // End empty pages check.
+	endif; // End hierarchical check.
+
+	if ( count( get_page_templates( $post ) ) > 0 && (int) get_option( 'page_for_posts' ) !== $post->ID ) :
+		$template = ! empty( $post->page_template ) ? $post->page_template : false;
+			?>
+<p class="post-attributes-label-wrapper page-template-label-wrapper"><label class="post-attributes-label" for="page_template"><?php _e( 'Template' ); ?></label>
+		<?php
+		/**
+		 * Fires immediately after the label inside the 'Template' section
+		 * of the 'Page Attributes' meta box.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param string|false $template The template used for the current post.
+		 * @param WP_Post      $post     The current post.
+		 */
+		do_action( 'page_attributes_meta_box_template', $template, $post );
+		?>
+</p>
+<select name="page_template" id="page_template">
+		<?php
+		/**
+		 * Filters the title of the default page template displayed in the drop-down.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param string $label   The display value for the default page template title.
+		 * @param string $context Where the option label is displayed. Possible values
+		 *                        include 'meta-box' or 'quick-edit'.
+		 */
+		$default_title = apply_filters( 'default_page_template_title', __( 'Default template' ), 'meta-box' );
+		?>
+<option value="default"><?php echo esc_html( $default_title ); ?></option>
+		<?php page_template_dropdown( $template, $post->post_type ); ?>
+</select>
+<?php endif; ?>
+	<?php if ( post_type_supports( $post->post_type, 'page-attributes' ) ) : ?>
+<p class="post-attributes-label-wrapper menu-order-label-wrapper"><label class="post-attributes-label" for="menu_order"><?php _e( 'Order' ); ?></label></p>
+<input name="menu_order" type="text" size="4" id="menu_order" value="<?php echo esc_attr( $post->menu_order ); ?>" />
+		<?php
+		/**
+		 * Fires before the help hint text in the 'Page Attributes' meta box.
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param WP_Post $post The current post.
+		 */
+		do_action( 'page_attributes_misc_attributes', $post );
+		?>
+		<?php if ( 'page' === $post->post_type && get_current_screen()->get_help_tabs() ) : ?>
+<p class="post-attributes-help-text"><?php _e( 'Need help? Use the Help tab above the screen title.' ); ?></p>
+			<?php
+		endif;
+	endif;
+}
+
+//
+// Link-related Meta Boxes.
+//
+
+/**
+ * Displays link create form fields.
+ *
+ * @since 2.7.0
+ *
+ * @param object $link Current link object.
+ */
+function link_submit_meta_box( $link ) {
+			?>
+<div class="submitbox" id="submitlink">
+
+<div id="minor-publishing">
+
+	<?php // Hidden submit button early on so that the browser chooses the right button when form is submitted with Return key. ?>
+<div style="display:none;">
+	<?php submit_button( __( 'Save' ), '', 'save', false ); ?>
+</div>
+
+<div id="minor-publishing-actions">
+<div id="preview-action">
+	<?php if ( ! empty( $link->link_id ) ) { ?>
+	<a class="preview button" href="<?php echo $link->link_url; ?>" target="_blank"><?php _e( 'Visit Link' ); ?></a>
+<?php } ?>
+</div>
+<div class="clear"></div>
+</div>
+
+<div id="misc-publishing-actions">
+<div class="misc-pub-section misc-pub-private">
+	<label for="link_private" class="selectit"><input id="link_private" name="link_visible" type="checkbox" value="N" <?php checked( $link->link_visible, 'N' ); ?> /> <?php _e( 'Keep this link private' ); ?></label>
+</div>
+</div>
+
+</div>
+
+<div id="major-publishing-actions">
+	<?php
+	/** This action is documented in wp-admin/includes/meta-boxes.php */
+	do_action( 'post_submitbox_start', null );
+	?>
+<div id="delete-action">
+	<?php
+	if ( ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] && current_user_can( 'manage_links' ) ) {
+		printf(
+			'<a class="submitdelete deletion" href="%s" onclick="return confirm( \'%s\' );">%s</a>',
+			wp_nonce_url( "link.php?action=delete&amp;link_id=$link->link_id", 'delete-bookmark_' . $link->link_id ),
+			/* translators: %s: Link name. */
+			esc_js( sprintf( __( "You are about to delete this link '%s'\n  'Cancel' to stop, 'OK' to delete." ), $link->link_name ) ),
+			__( 'Delete' )
+		);
+	}
+	?>
+</div>
+
+<div id="publishing-action">
+	<?php if ( ! empty( $link->link_id ) ) { ?>
+	<input name="save" type="submit" class="button button-primary button-large" id="publish" value="<?php esc_attr_e( 'Update Link' ); ?>" />
+<?php } else { ?>
+	<input name="save" type="submit" class="button button-primary button-large" id="publish" value="<?php esc_attr_e( 'Add Link' ); ?>" />
+<?php } ?>
+</div>
+<div class="clear"></div>
+</div>
+	<?php
+	/**
+	 * Fires at the end of the Publish box in the Link editing screen.
+	 *
+	 * @since 2.5.0
+	 */
+	do_action( 'submitlink_box' );
+	?>
+<div class="clear"></div>
+</div>
+	<?php
+}
+
+/**
+ * Displays link categories form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_categories_meta_box( $link ) {
+	?>
+<div id="taxonomy-linkcategory" class="categorydiv">
+	<ul id="category-tabs" class="category-tabs">
+		<li class="tabs"><a href="#categories-all"><?php _e( 'All categories' ); ?></a></li>
+		<li class="hide-if-no-js"><a href="#categories-pop"><?php _ex( 'Most Used', 'categories' ); ?></a></li>
+	</ul>
+
+	<div id="categories-all" class="tabs-panel">
+		<ul id="categorychecklist" data-wp-lists="list:category" class="categorychecklist form-no-clear">
+			<?php
+			if ( isset( $link->link_id ) ) {
+				wp_link_category_checklist( $link->link_id );
+			} else {
+				wp_link_category_checklist();
+			}
+			?>
+		</ul>
+	</div>
+
+	<div id="categories-pop" class="tabs-panel" style="display: none;">
+		<ul id="categorychecklist-pop" class="categorychecklist form-no-clear">
+			<?php wp_popular_terms_checklist( 'link_category' ); ?>
+		</ul>
+	</div>
+
+	<div id="category-adder" class="wp-hidden-children">
+		<a id="category-add-toggle" href="#category-add" class="taxonomy-add-new"><?php _e( '+ Add New Category' ); ?></a>
+		<p id="link-category-add" class="wp-hidden-child">
+			<label class="screen-reader-text" for="newcat">
+				<?php
+				/* translators: Hidden accessibility text. */
+				_e( '+ Add New Category' );
+				?>
+			</label>
+			<input type="text" name="newcat" id="newcat" class="form-required form-input-tip" value="<?php esc_attr_e( 'New category name' ); ?>" aria-required="true" />
+			<input type="button" id="link-category-add-submit" data-wp-lists="add:categorychecklist:link-category-add" class="button" value="<?php esc_attr_e( 'Add' ); ?>" />
+			<?php wp_nonce_field( 'add-link-category', '_ajax_nonce', false ); ?>
+			<span id="category-ajax-response"></span>
+		</p>
+	</div>
+</div>
+	<?php
+}
+
+/**
+ * Displays form fields for changing link target.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_target_meta_box( $link ) {
+
+	?>
+<fieldset><legend class="screen-reader-text"><span>
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Target' );
+	?>
+</span></legend>
+<p><label for="link_target_blank" class="selectit">
+<input id="link_target_blank" type="radio" name="link_target" value="_blank" <?php echo ( isset( $link->link_target ) && ( '_blank' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
+	<?php _e( '<code>_blank</code> &mdash; new window or tab.' ); ?></label></p>
+<p><label for="link_target_top" class="selectit">
+<input id="link_target_top" type="radio" name="link_target" value="_top" <?php echo ( isset( $link->link_target ) && ( '_top' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
+	<?php _e( '<code>_top</code> &mdash; current window or tab, with no frames.' ); ?></label></p>
+<p><label for="link_target_none" class="selectit">
+<input id="link_target_none" type="radio" name="link_target" value="" <?php echo ( isset( $link->link_target ) && ( '' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
+	<?php _e( '<code>_none</code> &mdash; same window or tab.' ); ?></label></p>
+</fieldset>
+<p><?php _e( 'Choose the target frame for your link.' ); ?></p>
+	<?php
+}
+
+/**
+ * Displays 'checked' checkboxes attribute for XFN microformat options.
+ *
+ * @since 1.0.1
+ *
+ * @global object $link Current link object.
+ *
+ * @param string $xfn_relationship XFN relationship category. Possible values are:
+ *                                 'friendship', 'physical', 'professional',
+ *                                 'geographical', 'family', 'romantic', 'identity'.
+ * @param string $xfn_value        Optional. The XFN value to mark as checked
+ *                                 if it matches the current link's relationship.
+ *                                 Default empty string.
+ * @param mixed  $deprecated       Deprecated. Not used.
+ */
+function xfn_check( $xfn_relationship, $xfn_value = '', $deprecated = '' ) {
+	global $link;
+
+	if ( ! empty( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '2.5.0' ); // Never implemented.
+	}
+
+	$link_rel  = isset( $link->link_rel ) ? $link->link_rel : ''; // In PHP 5.3: $link_rel = $link->link_rel ?: '';
+	$link_rels = preg_split( '/\s+/', $link_rel );
+
+	// Mark the specified value as checked if it matches the current link's relationship.
+	if ( '' !== $xfn_value && in_array( $xfn_value, $link_rels, true ) ) {
+		echo ' checked="checked"';
+	}
+
+	if ( '' === $xfn_value ) {
+		// Mark the 'none' value as checked if the current link does not match the specified relationship.
+		if ( 'family' === $xfn_relationship
+				&& ! array_intersect( $link_rels, array( 'child', 'parent', 'sibling', 'spouse', 'kin' ) ) ) {
+			echo ' checked="checked"';
+		}
+
+		if ( 'friendship' === $xfn_relationship
+				&& ! array_intersect( $link_rels, array( 'friend', 'acquaintance', 'contact' ) ) ) {
+			echo ' checked="checked"';
+		}
+
+		if ( 'geographical' === $xfn_relationship
+				&& ! array_intersect( $link_rels, array( 'co-resident', 'neighbor' ) ) ) {
+			echo ' checked="checked"';
+		}
+
+		// Mark the 'me' value as checked if it matches the current link's relationship.
+		if ( 'identity' === $xfn_relationship
+				&& in_array( 'me', $link_rels, true ) ) {
+			echo ' checked="checked"';
+		}
+	}
+}
+
+/**
+ * Displays XFN form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_xfn_meta_box( $link ) {
+	?>
+<table class="links-table">
+	<tr>
+		<th scope="row"><label for="link_rel"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'rel:' ); ?></label></th>
+		<td><input type="text" name="link_rel" id="link_rel" value="<?php echo ( isset( $link->link_rel ) ? esc_attr( $link->link_rel ) : '' ); ?>" /></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'identity' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'identity' );
+				?>
+			</span></legend>
+			<label for="me">
+			<input type="checkbox" name="identity" value="me" id="me" <?php xfn_check( 'identity', 'me' ); ?> />
+			<?php _e( 'another web address of mine' ); ?></label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'friendship' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'friendship' );
+				?>
+			</span></legend>
+			<label for="contact">
+			<input class="valinp" type="radio" name="friendship" value="contact" id="contact" <?php xfn_check( 'friendship', 'contact' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'contact' ); ?>
+			</label>
+			<label for="acquaintance">
+			<input class="valinp" type="radio" name="friendship" value="acquaintance" id="acquaintance" <?php xfn_check( 'friendship', 'acquaintance' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'acquaintance' ); ?>
+			</label>
+			<label for="friend">
+			<input class="valinp" type="radio" name="friendship" value="friend" id="friend" <?php xfn_check( 'friendship', 'friend' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'friend' ); ?>
+			</label>
+			<label for="friendship">
+			<input name="friendship" type="radio" class="valinp" value="" id="friendship" <?php xfn_check( 'friendship' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'none' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"> <?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'physical' ); ?> </th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'physical' );
+				?>
+			</span></legend>
+			<label for="met">
+			<input class="valinp" type="checkbox" name="physical" value="met" id="met" <?php xfn_check( 'physical', 'met' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'met' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"> <?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'professional' ); ?> </th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'professional' );
+				?>
+			</span></legend>
+			<label for="co-worker">
+			<input class="valinp" type="checkbox" name="professional" value="co-worker" id="co-worker" <?php xfn_check( 'professional', 'co-worker' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'co-worker' ); ?>
+			</label>
+			<label for="colleague">
+			<input class="valinp" type="checkbox" name="professional" value="colleague" id="colleague" <?php xfn_check( 'professional', 'colleague' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'colleague' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'geographical' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'geographical' );
+				?>
+			</span></legend>
+			<label for="co-resident">
+			<input class="valinp" type="radio" name="geographical" value="co-resident" id="co-resident" <?php xfn_check( 'geographical', 'co-resident' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'co-resident' ); ?>
+			</label>
+			<label for="neighbor">
+			<input class="valinp" type="radio" name="geographical" value="neighbor" id="neighbor" <?php xfn_check( 'geographical', 'neighbor' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'neighbor' ); ?>
+			</label>
+			<label for="geographical">
+			<input class="valinp" type="radio" name="geographical" value="" id="geographical" <?php xfn_check( 'geographical' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'none' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'family' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'family' );
+				?>
+			</span></legend>
+			<label for="child">
+			<input class="valinp" type="radio" name="family" value="child" id="child" <?php xfn_check( 'family', 'child' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'child' ); ?>
+			</label>
+			<label for="kin">
+			<input class="valinp" type="radio" name="family" value="kin" id="kin" <?php xfn_check( 'family', 'kin' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'kin' ); ?>
+			</label>
+			<label for="parent">
+			<input class="valinp" type="radio" name="family" value="parent" id="parent" <?php xfn_check( 'family', 'parent' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'parent' ); ?>
+			</label>
+			<label for="sibling">
+			<input class="valinp" type="radio" name="family" value="sibling" id="sibling" <?php xfn_check( 'family', 'sibling' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'sibling' ); ?>
+			</label>
+			<label for="spouse">
+			<input class="valinp" type="radio" name="family" value="spouse" id="spouse" <?php xfn_check( 'family', 'spouse' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'spouse' ); ?>
+			</label>
+			<label for="family">
+			<input class="valinp" type="radio" name="family" value="" id="family" <?php xfn_check( 'family' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'none' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+	<tr>
+		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'romantic' ); ?></th>
+		<td><fieldset>
+			<legend class="screen-reader-text"><span>
+				<?php
+				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
+				_e( 'romantic' );
+				?>
+			</span></legend>
+			<label for="muse">
+			<input class="valinp" type="checkbox" name="romantic" value="muse" id="muse" <?php xfn_check( 'romantic', 'muse' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'muse' ); ?>
+			</label>
+			<label for="crush">
+			<input class="valinp" type="checkbox" name="romantic" value="crush" id="crush" <?php xfn_check( 'romantic', 'crush' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'crush' ); ?>
+			</label>
+			<label for="date">
+			<input class="valinp" type="checkbox" name="romantic" value="date" id="date" <?php xfn_check( 'romantic', 'date' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'date' ); ?>
+			</label>
+			<label for="romantic">
+			<input class="valinp" type="checkbox" name="romantic" value="sweetheart" id="romantic" <?php xfn_check( 'romantic', 'sweetheart' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'sweetheart' ); ?>
+			</label>
+		</fieldset></td>
+	</tr>
+
+</table>
+<p><?php _e( 'If the link is to a person, you can specify your relationship with them using the above form. If you would like to learn more about the idea check out <a href="https://gmpg.org/xfn/">XFN</a>.' ); ?></p>
+	<?php
+}
+
+/**
+ * Displays advanced link options form fields.
+ *
+ * @since 2.6.0
+ *
+ * @param object $link Current link object.
+ */
+function link_advanced_meta_box( $link ) {
+	?>
+<table class="links-table" cellpadding="0">
+	<tr>
+		<th scope="row"><label for="link_image"><?php _e( 'Image Address' ); ?></label></th>
+		<td><input type="text" name="link_image" class="code" id="link_image" maxlength="255" value="<?php echo ( isset( $link->link_image ) ? esc_attr( $link->link_image ) : '' ); ?>" /></td>
+	</tr>
+	<tr>
+		<th scope="row"><label for="rss_uri"><?php _e( 'RSS Address' ); ?></label></th>
+		<td><input name="link_rss" class="code" type="text" id="rss_uri" maxlength="255" value="<?php echo ( isset( $link->link_rss ) ? esc_attr( $link->link_rss ) : '' ); ?>" /></td>
+	</tr>
+	<tr>
+		<th scope="row"><label for="link_notes"><?php _e( 'Notes' ); ?></label></th>
+		<td><textarea name="link_notes" id="link_notes" rows="10"><?php echo ( isset( $link->link_notes ) ? $link->link_notes : '' ); // textarea_escaped ?></textarea></td>
+	</tr>
+	<tr>
+		<th scope="row"><label for="link_rating"><?php _e( 'Rating' ); ?></label></th>
+		<td><select name="link_rating" id="link_rating" size="1">
+		<?php
+		for ( $rating = 0; $rating <= 10; $rating++ ) {
+			echo '<option value="' . $rating . '"';
+			if ( isset( $link->link_rating ) && $link->link_rating === $rating ) {
+				echo ' selected="selected"';
+			}
+			echo '>' . $rating . '</option>';
+		}
+		?>
+		</select>&nbsp;<?php _e( '(Leave at 0 for no rating.)' ); ?>
+		</td>
+	</tr>
+</table>
+	<?php
+}
+
+/**
+ * Displays post thumbnail meta box.
+ *
+ * @since 2.9.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function post_thumbnail_meta_box( $post ) {
+	$thumbnail_id = get_post_meta( $post->ID, '_thumbnail_id', true );
+	echo _wp_post_thumbnail_html( $thumbnail_id, $post->ID );
+}
+
+/**
+ * Displays fields for ID3 data.
+ *
+ * @since 3.9.0
+ *
+ * @param WP_Post $post Current post object.
+ */
+function attachment_id3_data_meta_box( $post ) {
+	$meta = array();
+	if ( ! empty( $post->ID ) ) {
+		$meta = wp_get_attachment_metadata( $post->ID );
+	}
+
+	foreach ( wp_get_attachment_id3_keys( $post, 'edit' ) as $key => $label ) :
+		$value = '';
+		if ( ! empty( $meta[ $key ] ) ) {
+			$value = $meta[ $key ];
+		}
+	?>
+	<p>
+		<label for="title"><?php echo $label; ?></label><br />
+		<input type="text" name="id3_<?php echo esc_attr( $key ); ?>" id="id3_<?php echo esc_attr( $key ); ?>" class="large-text" value="<?php echo esc_attr( $value ); ?>" />
+	</p>
+		<?php
+	endforeach;
+}
+
+/**
+ * Registers the default post meta boxes, and runs the `do_meta_boxes` actions.
+ *
+ * @since 5.0.0
+ *
+ * @param WP_Post $post The post object that these meta boxes are being generated for.
+ */
+function register_and_do_post_meta_boxes( $post ) {
+	$post_type        = $post->post_type;
+	$post_type_object = get_post_type_object( $post_type );
+
+	$thumbnail_support = current_theme_supports( 'post-thumbnails', $post_type ) && post_type_supports( $post_type, 'thumbnail' );
+	if ( ! $thumbnail_support && 'attachment' === $post_type && $post->post_mime_type ) {
+		if ( wp_attachment_is( 'audio', $post ) ) {
+			$thumbnail_support = post_type_supports( 'attachment:audio', 'thumbnail' ) || current_theme_supports( 'post-thumbnails', 'attachment:audio' );
+		} elseif ( wp_attachment_is( 'video', $post ) ) {
+			$thumbnail_support = post_type_supports( 'attachment:video', 'thumbnail' ) || current_theme_supports( 'post-thumbnails', 'attachment:video' );
+		}
+	}
+
+	$publish_callback_args = array( '__back_compat_meta_box' => true );
+
+	if ( post_type_supports( $post_type, 'revisions' ) && 'auto-draft' !== $post->post_status ) {
+		$revisions = wp_get_latest_revision_id_and_total_count( $post->ID );
+
+		// We should aim to show the revisions meta box only when there are revisions.
+		if ( ! is_wp_error( $revisions ) && $revisions['count'] > 1 ) {
+			$publish_callback_args = array(
+				'revisions_count'        => $revisions['count'],
+				'revision_id'            => $revisions['latest_id'],
+				'__back_compat_meta_box' => true,
+			);
+
+			add_meta_box( 'revisionsdiv', __( 'Revisions' ), 'post_revisions_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+		}
+	}
+
+	if ( 'attachment' === $post_type ) {
+		wp_enqueue_script( 'image-edit' );
+		wp_enqueue_style( 'imgareaselect' );
+		add_meta_box( 'submitdiv', __( 'Save' ), 'attachment_submit_meta_box', null, 'side', 'core', array( '__back_compat_meta_box' => true ) );
+		add_action( 'edit_form_after_title', 'edit_form_image_editor' );
+
+		if ( wp_attachment_is( 'audio', $post ) ) {
+			add_meta_box( 'attachment-id3', __( 'Metadata' ), 'attachment_id3_data_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+		}
+	} else {
+		add_meta_box( 'submitdiv', __( 'Publish' ), 'post_submit_meta_box', null, 'side', 'core', $publish_callback_args );
+	}
+
+	if ( current_theme_supports( 'post-formats' ) && post_type_supports( $post_type, 'post-formats' ) ) {
+		add_meta_box( 'formatdiv', _x( 'Format', 'post format' ), 'post_format_meta_box', null, 'side', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	// All taxonomies.
+	foreach ( get_object_taxonomies( $post ) as $tax_name ) {
+		$taxonomy = get_taxonomy( $tax_name );
+		if ( ! $taxonomy->show_ui || false === $taxonomy->meta_box_cb ) {
+			continue;
+		}
+
+		$label = $taxonomy->labels->name;
+
+		if ( ! is_taxonomy_hierarchical( $tax_name ) ) {
+			$tax_meta_box_id = 'tagsdiv-' . $tax_name;
+		} else {
+			$tax_meta_box_id = $tax_name . 'div';
+		}
+
+		add_meta_box(
+			$tax_meta_box_id,
+			$label,
+			$taxonomy->meta_box_cb,
+			null,
+			'side',
+			'core',
+			array(
+				'taxonomy'               => $tax_name,
+				'__back_compat_meta_box' => true,
+			)
+		);
+	}
+
+	if ( post_type_supports( $post_type, 'page-attributes' ) || count( get_page_templates( $post ) ) > 0 ) {
+		add_meta_box( 'pageparentdiv', $post_type_object->labels->attributes, 'page_attributes_meta_box', null, 'side', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( $thumbnail_support && current_user_can( 'upload_files' ) ) {
+		add_meta_box( 'postimagediv', esc_html( $post_type_object->labels->featured_image ), 'post_thumbnail_meta_box', null, 'side', 'low', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'excerpt' ) ) {
+		add_meta_box( 'postexcerpt', __( 'Excerpt' ), 'post_excerpt_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'trackbacks' ) ) {
+		add_meta_box( 'trackbacksdiv', __( 'Send Trackbacks' ), 'post_trackback_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'custom-fields' ) ) {
+		add_meta_box(
+			'postcustom',
+			__( 'Custom Fields' ),
+			'post_custom_meta_box',
+			null,
+			'normal',
+			'core',
+			array(
+				'__back_compat_meta_box'             => ! (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
+				'__block_editor_compatible_meta_box' => true,
+			)
+		);
+	}
+
+	/**
+	 * Fires in the middle of built-in meta box registration.
+	 *
+	 * @since 2.1.0
+	 * @deprecated 3.7.0 Use {@see 'add_meta_boxes'} instead.
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action_deprecated( 'dbx_post_advanced', array( $post ), '3.7.0', 'add_meta_boxes' );
+
+	/*
+	 * Allow the Discussion meta box to show up if the post type supports comments,
+	 * or if comments or pings are open.
+	 */
+	if ( comments_open( $post ) || pings_open( $post ) || post_type_supports( $post_type, 'comments' ) ) {
+		add_meta_box( 'commentstatusdiv', __( 'Discussion' ), 'post_comment_status_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	$stati = get_post_stati( array( 'public' => true ) );
+	if ( empty( $stati ) ) {
+		$stati = array( 'publish' );
+	}
+	$stati[] = 'private';
+
+	if ( in_array( get_post_status( $post ), $stati, true ) ) {
+		/*
+		 * If the post type support comments, or the post has comments,
+		 * allow the Comments meta box.
+		 */
+		if ( comments_open( $post ) || pings_open( $post ) || $post->comment_count > 0 || post_type_supports( $post_type, 'comments' ) ) {
+			add_meta_box( 'commentsdiv', __( 'Comments' ), 'post_comment_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+		}
+	}
+
+	if ( ! ( 'pending' === get_post_status( $post ) && ! current_user_can( $post_type_object->cap->publish_posts ) ) ) {
+		add_meta_box( 'slugdiv', __( 'Slug' ), 'post_slug_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	if ( post_type_supports( $post_type, 'author' ) && current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+		add_meta_box( 'authordiv', __( 'Author' ), 'post_author_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
+	}
+
+	/**
+	 * Fires after all built-in meta boxes have been added.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string  $post_type Post type.
+	 * @param WP_Post $post      Post object.
+	 */
+	do_action( 'add_meta_boxes', $post_type, $post );
+
+	/**
+	 * Fires after all built-in meta boxes have been added, contextually for the given post type.
+	 *
+	 * The dynamic portion of the hook name, `$post_type`, refers to the post type of the post.
+	 *
+	 * Possible hook names include:
+	 *
+	 *  - `add_meta_boxes_post`
+	 *  - `add_meta_boxes_page`
+	 *  - `add_meta_boxes_attachment`
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action( "add_meta_boxes_{$post_type}", $post );
+
+	/**
+	 * Fires after meta boxes have been added.
+	 *
+	 * Fires once for each of the default meta box contexts: normal, advanced, and side.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string                $post_type Post type of the post on Edit Post screen, 'link' on Edit Link screen,
+	 *                                         'dashboard' on Dashboard screen.
+	 * @param string                $context   Meta box context. Possible values include 'normal', 'advanced', 'side'.
+	 * @param WP_Post|object|string $post      Post object on Edit Post screen, link object on Edit Link screen,
+	 *                                         an empty string on Dashboard screen.
+	 */
+	do_action( 'do_meta_boxes', $post_type, 'normal', $post );
+	/** This action is documented in wp-admin/includes/meta-boxes.php */
+	do_action( 'do_meta_boxes', $post_type, 'advanced', $post );
+	/** This action is documented in wp-admin/includes/meta-boxes.php */
+	do_action( 'do_meta_boxes', $post_type, 'side', $post );
+}

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param array{insertSpaces?:bool|null,tabSize?:int|null,skipRules?:string[],addRules?:string[],skipFilters?:string[],callback?:(callable(Formatter): Formatter)|null} $options
+     * @param array{insertSpaces?:bool|null,tabSize?:2|4|8|null,skipRules?:string[],addRules?:string[],skipFilters?:string[],callback?:(callable(Formatter): Formatter)|null} $options
      */
     final public static function getFormatter(array $options): Formatter
     {
@@ -42,6 +42,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param string[] $addRules
      * @param string[] $skipRules
      * @param string[] $skipFilters
+     * @param 2|4|8 $tabSize
      */
     final public function assertCodeFormatIs(
         string $expected,


### PR DESCRIPTION
`FormatPhp`:
- Return 2 when invalid configuration files are found, 4 when one or more input files cannot be parsed, 8 when formatting is required in `--diff` or `--check` mode
- Stop looking for a configuration file when a `.svn` directory is found
- Don't print "Formatting 1 of 1: php://stdin" when reading TTY input
- Add initial fixtures for preset and config file unit tests
- Fix issue where output is written to standard output when an explicit `--output` file is given

`Formatter`:
- Reject tab sizes other than 2, 4 and 8
- Add `__construct()` parameters needed for immutability and adoption of `FormatterBuilder`

Also:
- Add `FilterException`, `RuleException`, `IncompatibleRulesException`, `InvalidConfigurationException`
- Add `--assets` and `--fixtures` options to `generate.sh`
- Update `Usage.md`