### PR TITLE
Fix error when `sort-imports` is disabled

### DIFF
--- a/src/Command/FormatPhp.php
+++ b/src/Command/FormatPhp.php
@@ -789,8 +789,8 @@ EOF,
         if ($this->ConfigFile !== null) {
             $this->IgnoreConfigFiles = true;
             // 1. Combine non-formatting options given on the command line with
-            //    formatting options from the configuration file to ensure the
-            //    former appear in `--print-config` output
+            //    formatting options from the configuration file to ensure
+            //    non-formatting options appear in `--print-config` output
             $config = array_intersect_key(
                 $this->getOptionValues(true, true, true),
                 self::SRC_OPTION_INDEX,
@@ -1197,6 +1197,7 @@ EOF,
         /** @var self */
         $clone = Get::copy($this);
         $clone->applyOptionValues($values + $defaults, true, true, true);
+        $clone->applyOptionValues($values, true, true, true, true, true);
         return $clone;
     }
 
@@ -1383,7 +1384,7 @@ EOF,
         }
 
         if (
-            $this->SortImportsBy &&
+            $this->optionHasArgument('sort-imports-by') &&
             ($this->NoSortImports || in_array('sort-imports', $this->Disable, true))
         ) {
             $throw(

--- a/src/Rule/DeclarationSpacing.php
+++ b/src/Rule/DeclarationSpacing.php
@@ -5,6 +5,7 @@ namespace Lkrms\PrettyPHP\Rule;
 use Lkrms\PrettyPHP\Catalog\TokenType;
 use Lkrms\PrettyPHP\Catalog\WhitespaceType;
 use Lkrms\PrettyPHP\Contract\MultiTokenRule;
+use Lkrms\PrettyPHP\Filter\SortImports;
 use Lkrms\PrettyPHP\Rule\Concern\MultiTokenRuleTrait;
 use Lkrms\PrettyPHP\Support\TokenTypeIndex;
 use Lkrms\PrettyPHP\Token\Token;
@@ -102,7 +103,7 @@ final class DeclarationSpacing implements MultiTokenRule
                 continue;
             }
 
-            $parts = $token->declarationParts(false, false);
+            $parts = $token->namedDeclarationParts(false);
 
             // Ignore anonymous functions
             if (!$parts->count()) {
@@ -131,6 +132,15 @@ final class DeclarationSpacing implements MultiTokenRule
             )) {
                 $this->maybeApplyBlankLineBefore($token);
                 continue;
+            }
+
+            // Don't separate `use`, `use function` and `use constant` if
+            // imports are not being sorted
+            if (!($this->Formatter->Enabled[SortImports::class] ?? false) && (
+                $types === [\T_USE, \T_FUNCTION] ||
+                $types === [\T_USE, \T_CONST]
+            )) {
+                $types = [\T_USE];
             }
 
             // - `$this->PrevTypes` contains the `$types` of the most recent

--- a/tests/fixtures/Command/FormatPhp/invalid-sort-imports-1/.prettyphp
+++ b/tests/fixtures/Command/FormatPhp/invalid-sort-imports-1/.prettyphp
@@ -1,0 +1,4 @@
+{
+    "sortImportsBy": "name",
+    "noSortImports": true
+}

--- a/tests/fixtures/Command/FormatPhp/invalid-sort-imports-2/.prettyphp
+++ b/tests/fixtures/Command/FormatPhp/invalid-sort-imports-2/.prettyphp
@@ -1,0 +1,6 @@
+{
+    "disable": [
+        "sort-imports"
+    ],
+    "sortImportsBy": "name"
+}

--- a/tests/fixtures/Command/FormatPhp/no-sort-imports/.prettyphp
+++ b/tests/fixtures/Command/FormatPhp/no-sort-imports/.prettyphp
@@ -1,0 +1,3 @@
+{
+    "noSortImports": true
+}

--- a/tests/fixtures/Command/FormatPhp/no-sort-imports/Foo.php
+++ b/tests/fixtures/Command/FormatPhp/no-sort-imports/Foo.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Foo\Bar;
+
+use function substr;
+use function in_array;
+use Qux\Factory;
+use Foo\Exception\InvalidValueException;
+
+/**
+ * Summary
+ */
+class Foo
+{
+    public int $Bar;
+
+    public function __construct()
+    {
+        $a = 0;  // Short
+        $foo = 1;  // Long
+        $quuux = 2;  // Longer
+        $this->Bar = 3;  // Longest
+    }
+}

--- a/tests/unit/Rule/DeclarationSpacingTest.php
+++ b/tests/unit/Rule/DeclarationSpacingTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\PrettyPHP\Tests\Rule;
+
+use Lkrms\PrettyPHP\Filter\SortImports;
+use Lkrms\PrettyPHP\Formatter;
+use Lkrms\PrettyPHP\FormatterBuilder as FormatterB;
+
+final class DeclarationSpacingTest extends \Lkrms\PrettyPHP\Tests\TestCase
+{
+    /**
+     * @dataProvider outputProvider
+     *
+     * @param Formatter|FormatterB $formatter
+     */
+    public function testOutput(string $expected, string $code, $formatter): void
+    {
+        $this->assertFormatterOutputIs($expected, $code, $formatter);
+    }
+
+    /**
+     * @return array<array{string,string,Formatter|FormatterB}>
+     */
+    public static function outputProvider(): array
+    {
+        $formatterB = Formatter::build();
+        $formatter = $formatterB->go();
+
+        $input = <<<'PHP'
+<?php declare(strict_types=1);
+namespace Foo\Bar;
+use const PREG_UNMATCHED_AS_NULL;
+use const PREG_SET_ORDER;
+use function substr;
+use function in_array;
+use Qux\Factory;
+use Foo\Exception\InvalidValueException;
+/**
+ * Summary
+ */
+class Foo
+{
+    public int $Bar;
+    public string $Qux;
+    /**
+     * @var string[]
+     */
+    public array $Quux = [];
+    public function __construct(int $bar, string $qux)
+    {
+        $this->Bar = -1;
+        $this->Qux = $qux;
+    }
+}
+PHP;
+        return [
+            [
+                <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Foo\Bar;
+
+use Foo\Exception\InvalidValueException;
+use Qux\Factory;
+
+use function in_array;
+use function substr;
+
+use const PREG_SET_ORDER;
+use const PREG_UNMATCHED_AS_NULL;
+
+/**
+ * Summary
+ */
+class Foo
+{
+    public int $Bar;
+    public string $Qux;
+
+    /**
+     * @var string[]
+     */
+    public array $Quux = [];
+
+    public function __construct(int $bar, string $qux)
+    {
+        $this->Bar = -1;
+        $this->Qux = $qux;
+    }
+}
+
+PHP,
+                $input,
+                $formatter,
+            ],
+            [
+                <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Foo\Bar;
+
+use const PREG_UNMATCHED_AS_NULL;
+use const PREG_SET_ORDER;
+use function substr;
+use function in_array;
+use Qux\Factory;
+use Foo\Exception\InvalidValueException;
+
+/**
+ * Summary
+ */
+class Foo
+{
+    public int $Bar;
+    public string $Qux;
+
+    /**
+     * @var string[]
+     */
+    public array $Quux = [];
+
+    public function __construct(int $bar, string $qux)
+    {
+        $this->Bar = -1;
+        $this->Qux = $qux;
+    }
+}
+
+PHP,
+                $input,
+                $formatterB->disable([SortImports::class]),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- Fix issue where `--no-sort-imports` fails with "--sort-imports-by and --no-sort-imports/--disable=sort-imports cannot both be given"
- Suppress blank lines between `use`, `use function` and `use constant` groups when `sort-imports` is disabled
- Add tests for `--no-sort-imports` and equivalent configuration files
- Add unit test for `DeclarationSpacing`