### PR TITLE
Use less memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           key: composer-cache-${{ runner.os }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
           restore-keys: composer-cache-${{ runner.os }}-
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
         run: composer install --no-interaction --no-progress --no-dev
 
       - name: Run PHP CS Fixer
@@ -92,7 +92,7 @@ jobs:
           key: phpstan-cache-${{ runner.os }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: phpstan-cache-${{ runner.os }}-${{ matrix.php-version }}-
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
         run: composer install --no-interaction --no-progress
 
       - name: Run PHPStan
@@ -145,7 +145,7 @@ jobs:
           key: composer-cache-${{ runner.os }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
           restore-keys: composer-cache-${{ runner.os }}-
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
         run: composer install --no-interaction --no-progress
 
       - name: Run PHPUnit tests and generate code coverage report
@@ -193,7 +193,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install pandoc
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
         run: composer install --no-interaction --no-progress
 
       # Run the phar and man builds separately and together to test each code

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "salient/toolkit": "^0.99.0",
+        "salient/toolkit": "^0.99.10",
         "sebastian/diff": "^4 || ^5"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ee2dd56a899246226a1d50a2f44d545",
+    "content-hash": "b995801f1a53e73f997c58924dc2d7f8",
     "packages": [
         {
             "name": "lkrms/dice",
@@ -312,16 +312,16 @@
         },
         {
             "name": "salient/toolkit",
-            "version": "v0.99.0",
+            "version": "v0.99.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/salient-labs/toolkit.git",
-                "reference": "e2076efb719e2cbb10a9753ffff22a4079695078"
+                "reference": "7e97d970dc09a72456851e746f7d7671ab2f9984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/salient-labs/toolkit/zipball/e2076efb719e2cbb10a9753ffff22a4079695078",
-                "reference": "e2076efb719e2cbb10a9753ffff22a4079695078",
+                "url": "https://api.github.com/repos/salient-labs/toolkit/zipball/7e97d970dc09a72456851e746f7d7671ab2f9984",
+                "reference": "7e97d970dc09a72456851e746f7d7671ab2f9984",
                 "shasum": ""
             },
             "require": {
@@ -333,6 +333,9 @@
                 "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2",
                 "psr/log": "^1"
+            },
+            "conflict": {
+                "lkrms/util": "*"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "^1"
@@ -389,7 +392,7 @@
                 "issues": "https://github.com/salient-labs/toolkit/issues",
                 "source": "https://github.com/salient-labs/toolkit"
             },
-            "time": "2024-02-26T13:31:32+00:00"
+            "time": "2024-03-06T17:41:46+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/src/Command/FormatPhp.php
+++ b/src/Command/FormatPhp.php
@@ -33,15 +33,15 @@ use Lkrms\PrettyPHP\Support\TokenTypeIndex;
 use Lkrms\PrettyPHP\Token\Token;
 use Lkrms\PrettyPHP\Formatter;
 use Lkrms\PrettyPHP\FormatterBuilder;
-use Salient\Cli\Catalog\CliHelpSectionName;
-use Salient\Cli\Catalog\CliOptionType;
-use Salient\Cli\Catalog\CliOptionValueType;
-use Salient\Cli\Catalog\CliOptionValueUnknownPolicy;
-use Salient\Cli\Catalog\CliOptionVisibility as Visibility;
 use Salient\Cli\Exception\CliInvalidArgumentsException;
 use Salient\Cli\CliCommand;
 use Salient\Cli\CliOption;
-use Salient\Console\Catalog\ConsoleLevel;
+use Salient\Contract\Cli\CliHelpSectionName;
+use Salient\Contract\Cli\CliOptionType;
+use Salient\Contract\Cli\CliOptionValueType;
+use Salient\Contract\Cli\CliOptionValueUnknownPolicy;
+use Salient\Contract\Cli\CliOptionVisibility as Visibility;
+use Salient\Contract\Core\MessageLevel as Level;
 use Salient\Core\Facade\Console;
 use Salient\Core\Facade\Profile;
 use Salient\Core\Utility\Arr;
@@ -778,7 +778,7 @@ EOF,
         }
 
         if ($this->ReportTimers) {
-            $this->App->registerShutdownReport(ConsoleLevel::NOTICE);
+            $this->App->registerShutdownReport(Level::NOTICE);
         }
 
         if ($this->Tabs && $this->Spaces) {
@@ -1176,7 +1176,7 @@ EOF,
         if ($this->Diff) {
             if ($this->Quiet < 2) {
                 if ($replaced) {
-                    Console::out('', ConsoleLevel::INFO);
+                    Console::out('', Level::INFO);
                 }
                 Console::log(Inflect::format(
                     $count,

--- a/src/Contract/Filter.php
+++ b/src/Contract/Filter.php
@@ -2,15 +2,17 @@
 
 namespace Lkrms\PrettyPHP\Contract;
 
-use Lkrms\PrettyPHP\Token\Token;
+use PhpToken;
 
 interface Filter extends Extension
 {
     /**
      * Apply the filter to an array of tokens
      *
-     * @param Token[] $tokens
-     * @return Token[]
+     * @template T of PhpToken
+     *
+     * @param T[] $tokens
+     * @return T[]
      */
     public function filterTokens(array $tokens): array;
 }

--- a/src/Exception/IncompatibleRulesException.php
+++ b/src/Exception/IncompatibleRulesException.php
@@ -9,7 +9,7 @@ use Salient\Core\AbstractException;
 /**
  * Thrown when incompatible rules are enabled
  */
-class EnabledRulesAreNotCompatible extends AbstractException
+class IncompatibleRulesException extends AbstractException
 {
     /**
      * @var array<class-string<Rule>>

--- a/src/Filter/CollectColumn.php
+++ b/src/Filter/CollectColumn.php
@@ -2,8 +2,9 @@
 
 namespace Lkrms\PrettyPHP\Filter;
 
-use Lkrms\PrettyPHP\Concern\ExtensionTrait;
 use Lkrms\PrettyPHP\Contract\Filter;
+use Lkrms\PrettyPHP\Filter\Concern\FilterTrait;
+use Lkrms\PrettyPHP\Token\Token;
 use Salient\Core\Utility\Str;
 
 /**
@@ -11,10 +12,19 @@ use Salient\Core\Utility\Str;
  */
 final class CollectColumn implements Filter
 {
-    use ExtensionTrait;
+    use FilterTrait;
 
+    /**
+     * @inheritDoc
+     */
     public function filterTokens(array $tokens): array
     {
+        if (!$this->isArrayOf($tokens, Token::class)) {
+            // @codeCoverageIgnoreStart
+            return $tokens;
+            // @codeCoverageIgnoreEnd
+        }
+
         $tokens = array_values($tokens);
         $last = array_key_last($tokens);
         $column = 1;

--- a/src/Filter/Concern/FilterTrait.php
+++ b/src/Filter/Concern/FilterTrait.php
@@ -3,21 +3,35 @@
 namespace Lkrms\PrettyPHP\Filter\Concern;
 
 use Lkrms\PrettyPHP\Concern\ExtensionTrait;
-use Lkrms\PrettyPHP\Token\Token;
+use PhpToken;
 
 trait FilterTrait
 {
     use ExtensionTrait;
 
     /**
-     * @var Token[]
+     * @var PhpToken[]
      */
     protected array $Tokens;
 
     /**
+     * Check if the given tokens are instances of the given class
+     *
+     * @template T of PhpToken
+     *
+     * @param PhpToken[] $tokens
+     * @param class-string<T> $class
+     * @phpstan-assert-if-true T[] $tokens
+     */
+    protected function isArrayOf(array $tokens, string $class): bool
+    {
+        return $tokens && reset($tokens) instanceof $class;
+    }
+
+    /**
      * Get the given token's previous code token
      */
-    protected function prevCode(int $i): ?Token
+    protected function prevCode(int $i): ?PhpToken
     {
         while ($i--) {
             $token = $this->Tokens[$i];

--- a/src/Filter/RemoveHeredocIndentation.php
+++ b/src/Filter/RemoveHeredocIndentation.php
@@ -6,6 +6,7 @@ use Lkrms\PrettyPHP\Concern\ExtensionTrait;
 use Lkrms\PrettyPHP\Contract\Filter;
 use Lkrms\PrettyPHP\Token\Token;
 use Salient\Core\Utility\Pcre;
+use PhpToken;
 
 /**
  * Remove indentation from heredocs
@@ -14,13 +15,19 @@ final class RemoveHeredocIndentation implements Filter
 {
     use ExtensionTrait;
 
+    /**
+     * @template T of PhpToken
+     *
+     * @param T[] $tokens
+     * @return T[]
+     */
     public function filterTokens(array $tokens): array
     {
-        /** @var array<int,Token[]> */
+        /** @var array<int,T[]> */
         $heredocTokens = [];
         /** @var array<int,string[]> */
         $heredocText = [];
-        /** @var array<int,Token> */
+        /** @var array<int,T> */
         $stack = [];
         foreach ($tokens as $i => $token) {
             if ($stack) {
@@ -73,7 +80,12 @@ final class RemoveHeredocIndentation implements Filter
 
             // Finally, update each token
             foreach ($stripped as $j => $code) {
-                $heredocTokens[$i][$j]->setText($code);
+                $token = $heredocTokens[$i][$j];
+                if ($token instanceof Token) {
+                    $token->setText($code);
+                } else {
+                    $token->text = $code;
+                }
             }
         }
 

--- a/src/Filter/SortImports.php
+++ b/src/Filter/SortImports.php
@@ -5,9 +5,9 @@ namespace Lkrms\PrettyPHP\Filter;
 use Lkrms\PrettyPHP\Catalog\ImportSortOrder;
 use Lkrms\PrettyPHP\Contract\Filter;
 use Lkrms\PrettyPHP\Filter\Concern\FilterTrait;
-use Lkrms\PrettyPHP\Token\Token;
 use Salient\Core\Utility\Arr;
 use Salient\Core\Utility\Pcre;
+use PhpToken;
 
 /**
  * Sort consecutive alias/import statements
@@ -34,7 +34,10 @@ final class SortImports implements Filter
     private array $SortableImports;
 
     /**
-     * @inheritDoc
+     * @template T of PhpToken
+     *
+     * @param T[] $tokens
+     * @return T[]
      */
     public function filterTokens(array $tokens): array
     {
@@ -44,7 +47,7 @@ final class SortImports implements Filter
 
         // Identify relevant `T_USE` tokens and exit early if possible
         $tokens = [];
-        /** @var array<int,Token> */
+        /** @var array<int,T> */
         $stack = [];
         foreach ($this->Tokens as $i => $token) {
             if ($this->TypeIndex->OpenBrace[$token->id]) {
@@ -79,11 +82,11 @@ final class SortImports implements Filter
         while ($tokens) {
             $i = array_shift($tokens);
 
-            /** @var array<non-empty-array<Token>> */
+            /** @var array<non-empty-array<T>> */
             $sort = [];
-            /** @var Token[] */
+            /** @var T[] */
             $current = [];
-            /** @var Token|null */
+            /** @var T|null */
             $terminator = null;
             while ($i < $count) {
                 $token = $this->Tokens[$i];
@@ -145,9 +148,11 @@ final class SortImports implements Filter
     }
 
     /**
-     * @param non-empty-array<non-empty-array<Token>> $sort
-     * @param Token[] $tokens
-     * @return Token[]
+     * @template T of PhpToken
+     *
+     * @param non-empty-array<non-empty-array<T>> $sort
+     * @param T[] $tokens
+     * @return T[]
      */
     private function sortImports(array $sort, array $tokens): array
     {
@@ -190,7 +195,9 @@ final class SortImports implements Filter
     }
 
     /**
-     * @param Token[] $tokens
+     * @template T of PhpToken
+     *
+     * @param T[] $tokens
      * @return array{int,string}
      */
     private function sortableImport(array $tokens): array

--- a/src/Filter/TrimCasts.php
+++ b/src/Filter/TrimCasts.php
@@ -4,6 +4,7 @@ namespace Lkrms\PrettyPHP\Filter;
 
 use Lkrms\PrettyPHP\Concern\ExtensionTrait;
 use Lkrms\PrettyPHP\Contract\Filter;
+use Lkrms\PrettyPHP\Token\Token;
 
 /**
  * Remove whitespace inside cast operators
@@ -24,7 +25,12 @@ final class TrimCasts implements Filter
                     $token->id === \T_ARRAY_CAST ||
                     $token->id === \T_OBJECT_CAST ||
                     $token->id === \T_UNSET_CAST) {
-                $token->setText('(' . trim($token->text, " \n\r\t\v\0()") . ')');
+                $text = '(' . trim($token->text, " \n\r\t\v\0()") . ')';
+                if ($token instanceof Token) {
+                    $token->setText($text);
+                } else {
+                    $token->text = $text;
+                }
             }
         }
 

--- a/src/Support/TokenTypeIndex.php
+++ b/src/Support/TokenTypeIndex.php
@@ -3,8 +3,8 @@
 namespace Lkrms\PrettyPHP\Support;
 
 use Lkrms\PrettyPHP\Catalog\TokenType as TT;
+use Salient\Contract\Core\Immutable;
 use Salient\Core\Concern\HasImmutableProperties;
-use Salient\Core\Contract\Immutable;
 
 /**
  * Indexed tokens by type

--- a/src/Token/Concern/NavigableTokenTrait.php
+++ b/src/Token/Concern/NavigableTokenTrait.php
@@ -10,6 +10,7 @@ use Lkrms\PrettyPHP\Support\TokenTypeIndex;
 use Lkrms\PrettyPHP\Token\Token;
 use Lkrms\PrettyPHP\Formatter;
 use Salient\Core\Utility\Pcre;
+use PhpToken;
 
 trait NavigableTokenTrait
 {
@@ -136,12 +137,18 @@ trait NavigableTokenTrait
     public TokenTypeIndex $TypeIndex;
 
     /**
-     * @return Token[]
+     * @template T of PhpToken
+     *
+     * @param class-string<T> $class
+     * @return T[]
      */
-    public static function onlyTokenize(string $code, int $flags = 0, Filter ...$filters): array
+    public static function onlyTokenize(string $code, int $flags = 0, string $class = PhpToken::class, Filter ...$filters): array
     {
-        /** @var Token[] */
-        $tokens = parent::tokenize($code, $flags);
+        if (is_a($class, static::class, true)) {
+            $tokens = parent::tokenize($code, $flags);
+        } else {
+            $tokens = $class::tokenize($code, $flags);
+        }
 
         if (!$tokens || !$filters) {
             return $tokens;
@@ -159,7 +166,7 @@ trait NavigableTokenTrait
      */
     public static function tokenize(string $code, int $flags = 0, ?Formatter $formatter = null, Filter ...$filters): array
     {
-        $tokens = static::onlyTokenize($code, $flags, ...$filters);
+        $tokens = static::onlyTokenize($code, $flags, Token::class, ...$filters);
 
         if (!$tokens || !$formatter) {
             return $tokens;

--- a/tests/unit/Command/FormatPhpTest.php
+++ b/tests/unit/Command/FormatPhpTest.php
@@ -4,10 +4,10 @@ namespace Lkrms\PrettyPHP\Tests\Command;
 
 use Lkrms\PrettyPHP\Command\FormatPhp;
 use Salient\Cli\CliApplication;
-use Salient\Console\Catalog\ConsoleLevel as Level;
-use Salient\Console\Catalog\ConsoleLevelGroup as LevelGroup;
 use Salient\Console\Target\MockTarget;
-use Salient\Core\Contract\ExceptionInterface;
+use Salient\Contract\Core\ExceptionInterface;
+use Salient\Contract\Core\MessageLevel as Level;
+use Salient\Contract\Core\MessageLevelGroup as LevelGroup;
 use Salient\Core\Facade\Console;
 use Salient\Core\Utility\File;
 use Salient\Core\Utility\Json;

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -18,6 +18,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         if ($formatter instanceof FormatterB) {
             $formatter = $formatter->go();
         }
+        // Preserve `$formatter->Tokens` for inspection
+        $formatter = $formatter->withDebug();
         $first = $formatter->format($code);
         $second = $formatter->format($first, null, null, true);
         self::assertSame($expected, $first, 'Output is not formatted correctly.');


### PR DESCRIPTION
- Discard token array immediately after formatted code is rendered unless running in debug mode
- Use native `PhpToken::tokenize()` method to tokenize input and output for comparison

Also:
- Rename `EnabledRulesAreNotCompatible` to `IncompatibleRulesException`
- Continue `Formatter` cleanup
- Adopt latest `salient/toolkit`