### PR TITLE
Add more PHPDoc tags that prevent collapse of one-line DocBlocks

### DIFF
--- a/src/Contract/Rule.php
+++ b/src/Contract/Rule.php
@@ -20,6 +20,8 @@ interface Rule extends Extension
      */
     public static function getPriority(string $method): ?int;
 
-    /** @param Token[] $tokens */
+    /**
+     * @param Token[] $tokens
+     */
     public function beforeRender(array $tokens): void;
 }

--- a/tests/fixtures/Formatter/out/01-default/3rdparty/phpfmt/158-space-between-methods
+++ b/tests/fixtures/Formatter/out/01-default/3rdparty/phpfmt/158-space-between-methods
@@ -7,6 +7,9 @@ class A
 
     // adsa
     function c() {}
-    /** @return something */
+
+    /**
+     * @return something
+     */
     function d() {}
 }

--- a/tests/fixtures/Formatter/out/02-aligned/3rdparty/phpfmt/158-space-between-methods
+++ b/tests/fixtures/Formatter/out/02-aligned/3rdparty/phpfmt/158-space-between-methods
@@ -7,6 +7,9 @@ class A
 
     // adsa
     function c() {}
-    /** @return something */
+
+    /**
+     * @return something
+     */
     function d() {}
 }

--- a/tests/fixtures/Formatter/out/03-tab/3rdparty/phpfmt/158-space-between-methods
+++ b/tests/fixtures/Formatter/out/03-tab/3rdparty/phpfmt/158-space-between-methods
@@ -7,6 +7,9 @@ class A
 
 	// adsa
 	function c() {}
-	/** @return something */
+
+	/**
+	 * @return something
+	 */
 	function d() {}
 }

--- a/tests/fixtures/Formatter/out/04-psr12/3rdparty/phpfmt/158-space-between-methods
+++ b/tests/fixtures/Formatter/out/04-psr12/3rdparty/phpfmt/158-space-between-methods
@@ -8,6 +8,9 @@ class A
 
     // adsa
     function c() {}
-    /** @return something */
+
+    /**
+     * @return something
+     */
     function d() {}
 }


### PR DESCRIPTION
- In addition to `@inheritDoc`, never collapse one-line DocBlocks with one of the following tags, with or without a `@phan-`, `@psalm-` or `@phpstan-` prefix:
  - `@api`
  - `@internal`
  - `@method`
  - `@property`, `@property-read`, `@property-write`
  - `@param`
  - `@return`
  - `@throws`