### PR TITLE
Review `SortImports` and `Symfony`

### DIFF
--- a/src/Filter/Concern/FilterTrait.php
+++ b/src/Filter/Concern/FilterTrait.php
@@ -13,13 +13,13 @@ trait FilterTrait
 {
     use ExtensionTrait;
 
-    /** @var GenericToken[] */
+    /** @var list<GenericToken> */
     protected array $Tokens;
 
     /**
      * Get the given token's previous code token
      */
-    protected function prevCode(int $i): ?GenericToken
+    protected function getPrevCode(int $i): ?GenericToken
     {
         while ($i--) {
             $token = $this->Tokens[$i];

--- a/src/Filter/NormaliseNames.php
+++ b/src/Filter/NormaliseNames.php
@@ -2,8 +2,8 @@
 
 namespace Lkrms\PrettyPHP\Filter;
 
+use Lkrms\PrettyPHP\Concern\ExtensionTrait;
 use Lkrms\PrettyPHP\Contract\Filter;
-use Lkrms\PrettyPHP\Filter\Concern\FilterTrait;
 
 /**
  * Convert namespaced names to PHP 8.0 name tokens
@@ -12,7 +12,7 @@ use Lkrms\PrettyPHP\Filter\Concern\FilterTrait;
  */
 final class NormaliseNames implements Filter
 {
-    use FilterTrait;
+    use ExtensionTrait;
 
     /**
      * @inheritDoc

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -348,8 +348,8 @@ final class Formatter implements Buildable
         RemoveWhitespace::class,
         RemoveHeredocIndentation::class,
         RemoveEmptyDocBlocks::class,
-        MoveComments::class,
         SortImports::class,
+        MoveComments::class,
         TrimCasts::class,
     ];
 
@@ -358,8 +358,8 @@ final class Formatter implements Buildable
      */
     public const OPTIONAL_FILTERS = [
         RemoveEmptyDocBlocks::class,
-        MoveComments::class,
         SortImports::class,
+        MoveComments::class,
         TrimCasts::class,
     ];
 
@@ -1203,6 +1203,7 @@ final class Formatter implements Buildable
         }
 
         Profile::startTimer(__METHOD__ . '#parse-output');
+        $this->resetExtensions($this->ComparisonFilterList);
         try {
             $after = Token::tokenizeForComparison(
                 $out,
@@ -1224,6 +1225,7 @@ final class Formatter implements Buildable
             Profile::stopTimer(__METHOD__ . '#parse-output');
         }
 
+        $this->resetExtensions($this->ComparisonFilterList);
         $before = Token::tokenizeForComparison(
             $code,
             \TOKEN_PARSE,
@@ -1403,9 +1405,13 @@ final class Formatter implements Buildable
         return $ext;
     }
 
-    private function resetExtensions(): void
+    /**
+     * @param Extension[]|null $extensions
+     */
+    private function resetExtensions(?array $extensions = null): void
     {
-        foreach ($this->Extensions as $ext) {
+        $extensions ??= $this->Extensions;
+        foreach ($extensions as $ext) {
             $ext->reset();
         }
     }

--- a/src/Rule/Preset/Symfony.php
+++ b/src/Rule/Preset/Symfony.php
@@ -3,6 +3,7 @@
 namespace Lkrms\PrettyPHP\Rule\Preset;
 
 use Lkrms\PrettyPHP\Catalog\HeredocIndent;
+use Lkrms\PrettyPHP\Catalog\ImportSortOrder;
 use Lkrms\PrettyPHP\Catalog\WhitespaceType;
 use Lkrms\PrettyPHP\Contract\ListRule;
 use Lkrms\PrettyPHP\Contract\Preset;
@@ -38,6 +39,7 @@ final class Symfony implements Preset, TokenRule, ListRule
                    ->flags($flags)
                    ->tokenTypeIndex((new TokenTypeIndex())->withLeadingOperators())
                    ->heredocIndent(HeredocIndent::NONE)
+                   ->importSortOrder(ImportSortOrder::NAME)
                    ->collapseEmptyDeclarationBodies(false)
                    ->collapseDeclareHeaders(false)
                    ->expandHeaders()
@@ -69,17 +71,13 @@ final class Symfony implements Preset, TokenRule, ListRule
     public function processTokens(array $tokens): void
     {
         foreach ($tokens as $token) {
-            switch ($token->id) {
-                case \T_CONCAT;
-                    $token->WhitespaceMaskPrev &= ~WhitespaceType::SPACE;
-                    $token->WhitespaceMaskNext &= ~WhitespaceType::SPACE;
-                    continue 2;
-
-                case \T_FN:
-                    $token->WhitespaceAfter |= WhitespaceType::SPACE;
-                    $token->WhitespaceMaskNext |= WhitespaceType::SPACE;
-                    continue 2;
+            if ($token->id === \T_CONCAT) {
+                $token->WhitespaceMaskPrev &= ~WhitespaceType::SPACE;
+                $token->WhitespaceMaskNext &= ~WhitespaceType::SPACE;
+                continue;
             }
+            $token->WhitespaceAfter |= WhitespaceType::SPACE;
+            $token->WhitespaceMaskNext |= WhitespaceType::SPACE;
         }
     }
 

--- a/tests/fixtures/App/FormatPhpCommand/preset/symfony/standards.in
+++ b/tests/fixtures/App/FormatPhpCommand/preset/symfony/standards.in
@@ -28,6 +28,9 @@ class FooBar {
         trigger_deprecation('symfony/package-name', '5.1', 'The %s() method is deprecated, use Acme\Baz::someMethod() instead.', __METHOD__);
         return Baz::someMethod();
     }
+    public function getClosure(): \Closure {
+        return fn() => null;
+    }
     /**
      * Transforms the input given as the first argument.
      *
@@ -53,7 +56,7 @@ class FooBar {
         $mergedOptions = array_merge($defaultOptions, $options);
 
         if (true === $dummy) {
-            return 'something';
+            return 'something' . ' or other';
         }
 
         if (\is_string($dummy)) {

--- a/tests/fixtures/App/FormatPhpCommand/preset/symfony/standards.out
+++ b/tests/fixtures/App/FormatPhpCommand/preset/symfony/standards.out
@@ -44,6 +44,11 @@ class FooBar
         return Baz::someMethod();
     }
 
+    public function getClosure(): \Closure
+    {
+        return fn () => null;
+    }
+
     /**
      * Transforms the input given as the first argument.
      *
@@ -67,7 +72,7 @@ class FooBar
         $mergedOptions = array_merge($defaultOptions, $options);
 
         if (true === $dummy) {
-            return 'something';
+            return 'something'.' or other';
         }
 
         if (\is_string($dummy)) {

--- a/tests/unit/Filter/SortImportsTest.php
+++ b/tests/unit/Filter/SortImportsTest.php
@@ -98,25 +98,65 @@ use A;
 PHP,
                 $formatter,
             ],
-            'sorted by depth' => [
+            'with comments #3' => [
                 <<<'PHP'
 <?php
-use B\C\F\{H, I};
-use B\C\F\G;
-use B\C\F\J;
-use B\C\E;
-use B\D;
+// Comment 1
+use B;
+use C;
+// Comment 2
 use A;
 
 PHP,
                 <<<'PHP'
 <?php
-use B\C\F\J;
+// Comment 1
+use C;
+use B;
+// Comment 2
+use A;
+PHP,
+                $formatter,
+            ],
+            'sorted by depth' => [
+                <<<'PHP'
+<?php
+use B\C\F\H\A as AA;
+use B\C\F\H\H as HHHH;
+use B\C\F\H\M;
+use B\C\F\{H, J};
+use B\C\F\{H as HH, K};
+use B\C\F\G;
+use B\C\F\H as HHH;
+use B\C\F\I;
+use B\C\E;
+use B\C\F as FF;
+use B\C;
+use B\D;
+use S\T\U\F\F;
+use A;
+use B;
+use L;
+
+PHP,
+                <<<'PHP'
+<?php
+use B\C\F\I;
 use B\D;
 use A;
 use B\C\E;
-use B\C\F\{H, I};
+use B\C\F\{H,J};
 use B\C\F\G;
+use B\C\F\H as HHH;
+use B\C\F\H\M;
+use B\C\F\H\H as HHHH;
+use B\C\F\H\A as AA;
+use B\C\F\{H as HH,K};
+use L;
+use S\T\U\F\F;
+use B;
+use B\C;
+use B\C\F as FF;
 PHP,
                 $formatter,
             ],
@@ -124,21 +164,41 @@ PHP,
                 <<<'PHP'
 <?php
 use A;
+use B;
+use B\C;
 use B\C\E;
+use B\C\F as FF;
 use B\C\F\G;
-use B\C\F\{H, I};
-use B\C\F\J;
+use B\C\F\{H, J};
+use B\C\F\{H as HH, K};
+use B\C\F\H as HHH;
+use B\C\F\H\A as AA;
+use B\C\F\H\H as HHHH;
+use B\C\F\H\M;
+use B\C\F\I;
 use B\D;
+use L;
+use S\T\U\F\F;
 
 PHP,
                 <<<'PHP'
 <?php
-use B\C\F\J;
+use B\C\F\I;
 use B\D;
-use B\C\F\{H, I};
+use B\C\F\{H,J};
 use A;
 use B\C\F\G;
 use B\C\E;
+use B\C\F\H\M;
+use B\C\F\H\H as HHHH;
+use B\C\F\H\A as AA;
+use B\C\F\H as HHH;
+use B\C\F\{H as HH,K};
+use S\T\U\F\F;
+use L;
+use B\C\F as FF;
+use B\C;
+use B;
 PHP,
                 $formatterB
                     ->importSortOrder(ImportSortOrder::NAME),
@@ -182,6 +242,39 @@ use B { C::value insteadof D; }
 }
 PHP,
                 $formatter,
+            ],
+            'with close tag terminator' => [
+                <<<'PHP'
+<?php
+use A;
+use B;
+use C
+?>
+PHP,
+                <<<'PHP'
+<?php
+use C;
+use B;
+use A?>
+PHP,
+                $formatter,
+            ],
+            'with close tag terminator and comments' => [
+                <<<'PHP'
+<?php
+use A;  // Comment 3
+use B;  // Comment 2
+use C   // Comment 1
+?>
+PHP,
+                <<<'PHP'
+<?php
+use C;  // Comment 1
+use B;  // Comment 2
+use A   // Comment 3 ?>
+PHP,
+                $formatterB
+                    ->enable([AlignComments::class]),
             ],
         ];
     }


### PR DESCRIPTION
Working on the change discussed in #141 led to the discovery of unexpected results when sorting imports by name, so the relevant filter has been simplified and fixed, and additional tests have been added to cover import statement scenarios ranging from "possible" to "ridiculous".