### PR TITLE
Fix issue with ternary operator alignment after `static`

### DIFF
--- a/src/Support/TokenTypeIndex.php
+++ b/src/Support/TokenTypeIndex.php
@@ -109,13 +109,13 @@ class TokenTypeIndex implements HasTokenIndex, Immutable
     public array $ContinuesControlStructure;
 
     /**
-     * T_ABSTRACT, T_FINAL, T_PRIVATE, T_PROTECTED, T_PUBLIC, T_READONLY,
-     * T_STATIC, T_VAR
+     * T_ABSTRACT, T_CONST, T_FINAL, T_PRIVATE, T_PROTECTED, T_PUBLIC,
+     * T_READONLY, T_STATIC, T_VAR
      *
      * @readonly
      * @var array<int,bool>
      */
-    public array $VarOrModifier;
+    public array $NonMethodMember;
 
     /**
      * T_ATTRIBUTE_COMMENT, T_COMMENT, T_CONSTANT_ENCAPSED_STRING,
@@ -963,7 +963,8 @@ class TokenTypeIndex implements HasTokenIndex, Immutable
             \T_FINALLY,
         );
 
-        $this->VarOrModifier = self::get(
+        $this->NonMethodMember = self::get(
+            \T_CONST,
             \T_VAR,
             ...TG::KEYWORD_MODIFIER,
         );

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -552,9 +552,11 @@ class Token extends GenericToken implements HasTokenNames, JsonSerializable
         /** @var Token */
         $prevCode = $this->PrevCode;
         if (
-            $prevCode->id === \T_CONST
+            (
+                $this->Idx->NonMethodMember[$prevCode->id]
+                && $prevCode->inNamedDeclaration()
+            )
             || ($prevCode->id === \T_COLON && $prevCode->isColonTypeDelimiter())
-            || $this->Idx->VarOrModifier[$prevCode->id]
             || $this->inParameterList()
         ) {
             return TokenSubType::QUESTION_NULLABLE;

--- a/tests/fixtures/Formatter/in/issues/0151-ternary-alignment-after-static.php
+++ b/tests/fixtures/Formatter/in/issues/0151-ternary-alignment-after-static.php
@@ -1,0 +1,3 @@
+<?php
+$obj instanceof static
+    ?true: false;

--- a/tests/fixtures/Formatter/out/01-default/issues/0151-ternary-alignment-after-static.php
+++ b/tests/fixtures/Formatter/out/01-default/issues/0151-ternary-alignment-after-static.php
@@ -1,0 +1,4 @@
+<?php
+$obj instanceof static
+    ? true
+    : false;

--- a/tests/fixtures/Formatter/out/02-aligned/issues/0151-ternary-alignment-after-static.php
+++ b/tests/fixtures/Formatter/out/02-aligned/issues/0151-ternary-alignment-after-static.php
@@ -1,0 +1,4 @@
+<?php
+$obj instanceof static
+    ? true
+    : false;

--- a/tests/fixtures/Formatter/out/03-tab/issues/0151-ternary-alignment-after-static.php
+++ b/tests/fixtures/Formatter/out/03-tab/issues/0151-ternary-alignment-after-static.php
@@ -1,0 +1,4 @@
+<?php
+$obj instanceof static
+	? true
+	: false;

--- a/tests/fixtures/Formatter/out/04-psr12/issues/0151-ternary-alignment-after-static.php
+++ b/tests/fixtures/Formatter/out/04-psr12/issues/0151-ternary-alignment-after-static.php
@@ -1,0 +1,4 @@
+<?php
+$obj instanceof static
+    ? true
+    : false;


### PR DESCRIPTION
Fixes #151