### PR TITLE
Improve `PreserveOneLineStatements`

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -271,6 +271,12 @@ If a `switch` case and its statement list are on the same line in the input, the
 
 Attributes on their own line are excluded from consideration.
 
+For any control structures that remain where every `if`/`elseif`/`else` or `try`/`catch`/`finally` statement starts and ends on the same line in the input:
+
+- newlines are added before each `elseif`/`else`/`catch`/`finally` token
+- newlines are suppressed between tokens in each statement
+- blank lines are added before and after the control structure
+
 ### `BlankBeforeReturn`
 
 <small>(optional, `processTokens()`, priority 204, tokens: `T_YIELD` | `T_YIELD_FROM` | `T_RETURN`)</small>

--- a/src/AbstractTokenIndex.php
+++ b/src/AbstractTokenIndex.php
@@ -484,6 +484,17 @@ abstract class AbstractTokenIndex implements HasTokenIndex, Immutable
         + self::TOKEN_INDEX;
 
     /**
+     * T_IF, T_TRY
+     *
+     * @var array<int,bool>
+     */
+    public array $IfOrTry = [
+        \T_IF => true,
+        \T_TRY => true,
+    ]
+        + self::TOKEN_INDEX;
+
+    /**
      * T_ELSEIF, T_ELSE
      *
      * @var array<int,bool>

--- a/src/Rule/PreserveOneLineStatements.php
+++ b/src/Rule/PreserveOneLineStatements.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\PrettyPHP\Rule;
 
+use Lkrms\PrettyPHP\Catalog\WhitespaceFlag as Space;
 use Lkrms\PrettyPHP\Concern\StatementRuleTrait;
 use Lkrms\PrettyPHP\Contract\StatementRule;
 use Lkrms\PrettyPHP\Token;
@@ -36,6 +37,14 @@ final class PreserveOneLineStatements implements StatementRule
      * input, they are treated as one statement.
      *
      * Attributes on their own line are excluded from consideration.
+     *
+     * For any control structures that remain where every `if`/`elseif`/`else`
+     * or `try`/`catch`/`finally` statement starts and ends on the same line in
+     * the input:
+     *
+     * - newlines are added before each `elseif`/`else`/`catch`/`finally` token
+     * - newlines are suppressed between tokens in each statement
+     * - blank lines are added before and after the control structure
      */
     public function processStatements(array $statements): void
     {
@@ -50,11 +59,53 @@ final class PreserveOneLineStatements implements StatementRule
             /** @var Token */
             $end = $token->EndStatement;
             if (
-                !$this->preserveOneLine($token, $end)
-                && $this->Idx->Attribute[$token->id]
+                $this->preserveOneLine($token, $end) || (
+                    $this->Idx->Attribute[$token->id]
+                    && $this->preserveOneLine(
+                        $token->skipNextSiblingFrom($this->Idx->Attribute),
+                        $end,
+                    )
+                )
             ) {
-                $start = $token->skipNextSiblingFrom($this->Idx->Attribute);
-                $this->preserveOneLine($start, $end);
+                continue;
+            }
+
+            if ($this->Idx->IfOrTry[$token->id]) {
+                $parts = $token->withNextSiblings($end)
+                               ->getAnyFrom($this->Idx->ContinuesControlStructure);
+                if (!$parts->isEmpty()) {
+                    $parts[] = $end;
+                    $first = $token;
+                    $lines = [];
+                    foreach ($parts as $next) {
+                        /** @var Token */
+                        $last = $next === $end
+                            ? $next
+                            : $next->PrevCode;
+                        if ($first->line !== $last->line) {
+                            $lines = [];
+                            break;
+                        }
+                        $lines[] = [$first, $last];
+                        $first = $next;
+                    }
+                    if ($lines) {
+                        foreach ($lines as [$first, $last]) {
+                            $this->preserveOneLine($first, $last, true);
+                            if ($first !== $token) {
+                                $first->applyWhitespace(Space::LINE_BEFORE);
+                            }
+                        }
+                        /** @var Token */
+                        $openTag = $token->OpenTag;
+                        if ($openTag->NextCode !== $token) {
+                            $token->applyBlankBefore();
+                        }
+                        if ($last->Next) {
+                            $last->Whitespace |= Space::BLANK_AFTER;
+                        }
+                    }
+                }
             }
         }
     }

--- a/tests/unit/Rule/PreserveOneLineStatementsTest.php
+++ b/tests/unit/Rule/PreserveOneLineStatementsTest.php
@@ -88,6 +88,51 @@ switch ($op) {
 PHP,
                 $formatter,
             ],
+            [
+                <<<'PHP'
+<?php
+if ($foo) { foo(); }  // comment
+elseif ($bar) { bar(); }  // comment
+else { baz(); }  // comment
+
+// comment
+if ($foo) { foo(); }
+elseif ($bar) { bar(); }
+else { baz(); }
+
+if ($foo) { foo(); }
+elseif ($bar) { bar(); }
+else if ($baz) { baz(); }
+else { qux(); }
+
+if ($foo) { foo(); }
+if ($foo) { foo(); } else { bar(); }
+
+try { foo(); }
+catch (LogicException $ex) { bar(); }
+catch (Throwable $ex) { baz(); }
+finally { qux(); }
+
+PHP,
+                <<<'PHP'
+<?php
+if ($foo) {foo();} // comment
+elseif ($bar) {bar();} // comment
+else {baz();} // comment
+// comment
+if ($foo) {foo();} elseif ($bar) {bar();}
+else {baz();}
+if ($foo) {foo();}
+elseif ($bar) {bar();} else if ($baz) {baz();} else {qux();}
+if ($foo) {foo();}
+if ($foo) {foo();} else {bar();}
+try {foo();}
+catch (LogicException $ex) {bar();}
+catch (Throwable $ex) {baz();}
+finally {qux();}
+PHP,
+                $formatter,
+            ],
         ];
 
         if (\PHP_VERSION_ID < 80000) {

--- a/tests/unit/Rule/PreserveOneLineStatementsTest.php
+++ b/tests/unit/Rule/PreserveOneLineStatementsTest.php
@@ -107,6 +107,11 @@ else { qux(); }
 
 if ($foo) { foo(); }
 if ($foo) { foo(); } else { bar(); }
+if ($foo) {
+    foo();
+} else {
+    bar();
+}
 
 try { foo(); }
 catch (LogicException $ex) { bar(); }
@@ -126,6 +131,9 @@ if ($foo) {foo();}
 elseif ($bar) {bar();} else if ($baz) {baz();} else {qux();}
 if ($foo) {foo();}
 if ($foo) {foo();} else {bar();}
+if ($foo) {foo();} else {
+    bar();
+}
 try {foo();}
 catch (LogicException $ex) {bar();}
 catch (Throwable $ex) {baz();}


### PR DESCRIPTION
- If `preserve-one-line` is enabled and there are multi-line control structures where `if`/`elseif`/`else` or `try`/`catch`/`finally` statements all start and end on the same line in the input:

  - add newlines before `elseif`/`else`/`catch`/`finally` tokens
  - suppress newlines between tokens in each statement
  - add blank lines before and after the control structure

  > This change allows for control structures like:
  >
  > ```php
  > <?php
  > if ($foo) { foo(); }
  > elseif ($bar) { bar(); }
  > else { baz(); }
  > ```